### PR TITLE
Fix: RTC test reworked to leave NVRAM usage in clean state(test_pool/…

### DIFF
--- a/tbsa-v8m/platform/board/fvp/tbsa_tgt.cfg
+++ b/tbsa-v8m/platform/board/fvp/tbsa_tgt.cfg
@@ -22,6 +22,7 @@ uart.0.base = 0x40004000;
 uart.0.offset = 0x0;
 uart.0.intr_id = 0xFF;
 uart.0.clk_src = 0x10000000;
+uart.0.stdio = 0x1;
 uart.0.attribute = NONSECURE_PROGRAMMABLE;
 
 timer.num = 2;
@@ -152,15 +153,12 @@ fuse.4.addr = 0x11;
 fuse.4.size = 0x1;
 
 //Miscellaneous
-boot.num = 1;
-boot.0.warm_support = 1;
-
 ver_count.num = 2;
 ver_count.0.fw_ver_type = TRUSTED;
-ver_count.0.fw_ver_cnt_max = 63;
+ver_count.0.fw_ver_cnt_max = 64;
 
 ver_count.1.fw_ver_type = NON_TRUSTED;
-ver_count.1.fw_ver_cnt_max = 255;
+ver_count.1.fw_ver_cnt_max = 256;
 
 dut.num = 1;
 dut.0.test_binary_src_addr = 0x10052800;

--- a/tbsa-v8m/tbsa_app/tbsa.h
+++ b/tbsa-v8m/tbsa_app/tbsa.h
@@ -24,10 +24,22 @@
 #define TBSA_ACS_MAJOR_VER    0
 #define TBSA_ACS_MINOR_VER    7
 
+uint32_t __tbsa_text_start__;
+uint32_t __tbsa_text_end__;
 uint32_t __tbsa_bss_start__;
 uint32_t __tbsa_bss_end__;
 uint32_t __tbsa_data_src_start__;
 uint32_t __tbsa_data_start__;
 uint32_t __tbsa_data_end__;
+uint32_t __tbsa_nsc_entry_points_start__;
+uint32_t __tbsa_nsc_entry_points_end__;
+uint32_t __tbsa_ns_data_start__;
+uint32_t __tbsa_ns_data_end__;
+uint32_t __tbsa_ns_text_start__;
+uint32_t __tbsa_ns_text_end__;
+uint32_t __tbsa_test_s_start__;
+uint32_t __tbsa_test_s_end__;
+uint32_t __tbsa_test_ns_start__;
+uint32_t __tbsa_test_ns_end__;
 
 #endif /* _TBSA_H_ */

--- a/tbsa-v8m/tbsa_app/tbsa_main.c
+++ b/tbsa-v8m/tbsa_app/tbsa_main.c
@@ -39,11 +39,32 @@ void tbsa_main (void)
         val_print(PRINT_ERROR, "\nVal Infra Init failed with error = %x ", status);
         goto exit;
     }
-    val_print(PRINT_ALWAYS, "\n\rTBSA Compliance Suite",0);
+    val_print(PRINT_ALWAYS, "\n\rTBSA Architecture Test Suite",0);
     val_print(PRINT_ALWAYS, "\n\rVersion :\t%d.", TBSA_ACS_MAJOR_VER);
-    val_print(PRINT_ALWAYS, "%d\n\n", TBSA_ACS_MINOR_VER);
+    val_print(PRINT_ALWAYS, "%d", TBSA_ACS_MINOR_VER);
+
+    val_print(PRINT_ALWAYS, "\n", 0);
+    val_print(PRINT_ALWAYS, "\n\r+----------------------------------------------------------------+", 0);
+    val_print(PRINT_ALWAYS, "\n\r|                       TBSA Memory Layout                       |", 0);
+    val_print(PRINT_ALWAYS, "\n\r+----------------------------------------------------------------+", 0);
+    val_print(PRINT_ALWAYS, "\n\r| Main App S_Text      : start - 0x%X\t", (uint32_t)&__tbsa_text_start__);
+    val_print(PRINT_ALWAYS, "end - 0x%X |", (uint32_t)&__tbsa_text_end__);
+    val_print(PRINT_ALWAYS, "\n\r| Main App S_Data      : start - 0x%X\t", (uint32_t)&__tbsa_data_start__);
+    val_print(PRINT_ALWAYS, "end - 0x%X |", (uint32_t)&__tbsa_bss_end__);
+    val_print(PRINT_ALWAYS, "\n\r| Main App NSC_Text    : start - 0x%X\t", (uint32_t)&__tbsa_nsc_entry_points_start__);
+    val_print(PRINT_ALWAYS, "end - 0x%X |", (uint32_t)&__tbsa_nsc_entry_points_end__);
+    val_print(PRINT_ALWAYS, "\n\r| Main App NS_Data     : start - 0x%X\t", (uint32_t)&__tbsa_ns_data_start__);
+    val_print(PRINT_ALWAYS, "end - 0x%X |", (uint32_t)&__tbsa_ns_data_end__);
+    val_print(PRINT_ALWAYS, "\n\r| Main App NS_Text     : start - 0x%X\t", (uint32_t)&__tbsa_ns_text_start__);
+    val_print(PRINT_ALWAYS, "end - 0x%X |", (uint32_t)&__tbsa_ns_text_end__);
+    val_print(PRINT_ALWAYS, "\n\r| Secure Test          : start - 0x%X\t", (uint32_t)&__tbsa_test_s_start__);
+    val_print(PRINT_ALWAYS, "end - 0x%X |", (uint32_t)&__tbsa_test_s_end__);
+    val_print(PRINT_ALWAYS, "\n\r| Non-secure Test      : start - 0x%X\t", (uint32_t)&__tbsa_test_ns_start__);
+    val_print(PRINT_ALWAYS, "end - 0x%X |", (uint32_t)&__tbsa_test_ns_end__);
+    val_print(PRINT_ALWAYS, "\n\r+----------------------------------------------------------------+", 0);
 
 
+    val_print(PRINT_ALWAYS, "\n\n\r+++ Starting tests +++", 0);
     /* Call the dispatcher routine*/
     tbsa_dispatcher(test_id_prev);
     val_print(PRINT_ALWAYS, "\n\n\rEntering standby\n", 0);

--- a/tbsa-v8m/test_pool/timer/test_t003/non_secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t003/non_secure.c
@@ -110,7 +110,7 @@ void test_payload(tbsa_val_api_t *val)
                 if (!val->is_rtc_trustable(soc_per_desc->base)) {
                     val->err_check_set(TEST_CHECKPOINT_A, TBSA_STATUS_INCORRECT_VALUE);
                     boot.cb = BOOT_UNKNOWN;
-                    status = val->nvram_write(memory_desc->start, TBSA_NVRAM_OFFSET(NV_SPAD), &boot, sizeof(boot));
+                    status = val->nvram_write(memory_desc->start, TBSA_NVRAM_OFFSET(NV_BOOT), &boot, sizeof(boot));
                     if (val->err_check_set(TEST_CHECKPOINT_B, status)) {
                         return;
                     }
@@ -121,7 +121,7 @@ void test_payload(tbsa_val_api_t *val)
                     /* When there is outage of power to the TRTC, TRTC is not trusted */
                     val->err_check_set(TEST_CHECKPOINT_C, TBSA_STATUS_INCORRECT_VALUE);
                     boot.cb = BOOT_UNKNOWN;
-                    status = val->nvram_write(memory_desc->start, TBSA_NVRAM_OFFSET(NV_SPAD), &boot, sizeof(boot));
+                    status = val->nvram_write(memory_desc->start, TBSA_NVRAM_OFFSET(NV_BOOT), &boot, sizeof(boot));
                     if (val->err_check_set(TEST_CHECKPOINT_D, status)) {
                         return;
                     }
@@ -191,10 +191,17 @@ void test_payload(tbsa_val_api_t *val)
 void exit_hook(tbsa_val_api_t *val)
 {
     tbsa_status_t status;
+    boot_t        boot;
 
     /* Restoring default Handler */
     status = val->interrupt_restore_handler(EXCP_NUM_HF);
     if (val->err_check_set(TEST_CHECKPOINT_12, status)) {
+        return;
+    }
+
+    boot.cb = BOOT_UNKNOWN;
+    status = val->nvram_write(memory_desc->start, TBSA_NVRAM_OFFSET(NV_BOOT), &boot, sizeof(boot));
+    if (val->err_check_set(TEST_CHECKPOINT_13, status)) {
         return;
     }
 }

--- a/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
+++ b/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
@@ -33,7 +33,7 @@ void
 hard_fault_esr (unsigned long *sf_args)
 {
     /* Issue system warm reset */
-    g_val->system_reset(WARM_RESET);
+    g_val->system_reset(COLD_RESET);
 
     /* Shouldn't come here */
     while(1);

--- a/tbsa-v8m/tools/gen_linker_scripts/gen_linker_scripts.py
+++ b/tbsa-v8m/tools/gen_linker_scripts/gen_linker_scripts.py
@@ -124,6 +124,20 @@ update_addr(dst_tbsa_linker, "TBSA_NSC_TEXT_START", \
                               nsc_addr)
 update_addr(dst_tbsa_linker, "TBSA_NSC_TEXT_LENGTH", \
                               TBSA_NSC_TEXT_LENGTH)
+update_addr(dst_tbsa_linker, "TBSA_TEST_S_START", \
+                              s_test_addr)
+update_addr(dst_tbsa_linker, "TBSA_TEST_S_END", \
+                              hex(int(s_test_addr, 16) + \
+                                 (int(TBSA_TEST_INFO_LENGTH[:TBSA_TEST_INFO_LENGTH.find("K")])*1024) + \
+                                 (int(TBSA_TEST_TEXT_LENGTH[:TBSA_TEST_TEXT_LENGTH.find("K")])*1024) + \
+                                 (int(TBSA_TEST_DATA_LENGTH[:TBSA_TEST_DATA_LENGTH.find("K")])*1024)))
+update_addr(dst_tbsa_linker, "TBSA_TEST_NS_START", \
+                              ns_test_addr)
+update_addr(dst_tbsa_linker, "TBSA_TEST_NS_END", \
+                              hex(int(ns_test_addr, 16) + \
+                                 (int(TBSA_TEST_INFO_LENGTH[:TBSA_TEST_INFO_LENGTH.find("K")])*1024) + \
+                                 (int(TBSA_TEST_TEXT_LENGTH[:TBSA_TEST_TEXT_LENGTH.find("K")])*1024) + \
+                                 (int(TBSA_TEST_DATA_LENGTH[:TBSA_TEST_DATA_LENGTH.find("K")])*1024)))
 
 # Updating S test linker script with address from target configuration file
 update_addr(dst_test_s_linker, "TBSA_TEST_INFO_START", \

--- a/tbsa-v8m/tools/gen_linker_scripts/tbsa.linker.template
+++ b/tbsa-v8m/tools/gen_linker_scripts/tbsa.linker.template
@@ -29,6 +29,7 @@ SECTIONS
 {
     .text :
     {
+        __tbsa_text_start__ = .;
         *(.text)
         *(.text*)
         *(.rodata)
@@ -36,6 +37,7 @@ SECTIONS
 
         KEEP(*(.init))
         KEEP(*(.fini))
+        __tbsa_text_end__ = .;
     } > TBSA_TEXT
 
     __tbsa_data_src_start__ = .;
@@ -81,10 +83,12 @@ SECTIONS
 
     .tbsa_ns_text :
     {
+        __tbsa_ns_text_start__ = .;
         *(.text)
         *(.text*)
         *(.rodata)
         *(.rodata*)
+        __tbsa_ns_text_end__ = .;
     } > TBSA_NS_TEXT
 
     .tbsa_nsc_entry_points :
@@ -96,8 +100,14 @@ SECTIONS
         __tbsa_nsc_entry_points_end__ = .;
     } > TBSA_NSC_TEXT
 
-    __TBSA_S_StackTop  = ORIGIN(TBSA_DATA) + LENGTH(TBSA_DATA);
-    __TBSA_NS_StackTop = ORIGIN(TBSA_NS_DATA) + LENGTH(TBSA_NS_DATA);
-    __TBSA_S_StackLimit  = ORIGIN(TBSA_DATA) + LENGTH(TBSA_DATA) - 0x400;
-    __TBSA_NS_StackLimit = ORIGIN(TBSA_NS_DATA) + LENGTH(TBSA_NS_DATA) - 0x400;
+    __TBSA_S_StackTop      = ORIGIN(TBSA_DATA) + LENGTH(TBSA_DATA);
+    __TBSA_NS_StackTop     = ORIGIN(TBSA_NS_DATA) + LENGTH(TBSA_NS_DATA);
+    __TBSA_S_StackLimit    = ORIGIN(TBSA_DATA) + LENGTH(TBSA_DATA) - 0x400;
+    __TBSA_NS_StackLimit   = ORIGIN(TBSA_NS_DATA) + LENGTH(TBSA_NS_DATA) - 0x400;
+
+    __tbsa_test_s_start__  = TBSA_TEST_S_START;
+    __tbsa_test_s_end__    = TBSA_TEST_S_END;
+    __tbsa_test_ns_start__ = TBSA_TEST_NS_START;
+    __tbsa_test_ns_end__   = TBSA_TEST_NS_END;
+
 }

--- a/tbsa-v8m/val/include/val_target.h
+++ b/tbsa-v8m/val/include/val_target.h
@@ -330,6 +330,7 @@ typedef struct _SOC_PER_INFO_DESC_ {
     uint32_t           intr_id;
     interrupt_target_t intr_target;
     addr_t             clk_src;
+    uint32_t           stdio;
     dev_attr_t         attribute;
 } soc_peripheral_desc_t;
 
@@ -421,7 +422,6 @@ typedef struct _MISCELLANEOUS_INFO_DESC_ {
     addr_t                  nsc_addr;
     addr_t                  s_test_addr;
     addr_t                  ns_test_addr;
-    uint32_t                warm_support;
     firmware_version_type_t fw_ver_type;
     uint32_t                fw_ver_cnt_max;
 } miscellaneous_desc_t;


### PR DESCRIPTION
…timer/test_t003).

Enhancements : Introduced a target configuration(tbsa_tgt.cfg) flag to identify UART to be used for stdio.
               Log enhanced to show memory layout.