### PR TITLE
Fixed compile error on Cygwin platform

### DIFF
--- a/api-tests/tools/scripts/targetConfigGen.pl
+++ b/api-tests/tools/scripts/targetConfigGen.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 #/** @file
-# * Copyright (c) 2018, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -232,7 +232,7 @@ print OUT "fprintf\(fp\, \"#endif \\n\"\)\;\n";
 print OUT "\nreturn 0;\}\/\/int main";
 
 #generate target_database.h file
-print "gcc -DTARGET_CFG_BUILD $output_c -o $build/platform/$target/targetConfigGen -I$source/val/nspe -I$source/val/common -I$source/platform/targets/$target/nspe/common\n";
-system("gcc -DTARGET_CFG_BUILD $output_c -o $build/platform/$target/targetConfigGen -I$source/val/nspe -I$source/val/common -I$source/platform/targets/$target/nspe/common") && die ("Failed to compile targetConfigGen.c \n");
+print "gcc -D__addr_t_defined -DTARGET_CFG_BUILD $output_c -o $build/platform/$target/targetConfigGen -I$source/val/nspe -I$source/val/common -I$source/platform/targets/$target/nspe/common\n";
+system("gcc -D__addr_t_defined -DTARGET_CFG_BUILD $output_c -o $build/platform/$target/targetConfigGen -I$source/val/nspe -I$source/val/common -I$source/platform/targets/$target/nspe/common") && die ("Failed to compile targetConfigGen.c \n");
 print "./$build/platform/$target/targetConfigGen\n";
 system("./$build/platform/$target/targetConfigGen ") && die ("Failed to generate targetConfig data base \n");


### PR DESCRIPTION
Since a lot of Cortex-M user use the windows platform. 
Support the Cygwin build is necessary.  

Here is  build error logs: 

In file included from /usr/include/sys/types.h:240:0,
                 from /usr/include/stdio.h:61,
                 from ./BUILD/platform/tgt_dev_apis_tfm_an521/targetConfigGen.c:2:
/usr/include/machine/types.h:74:15: error: conflicting types for ‘addr_t’
 typedef char *addr_t;
               ^~~~~~
In file included from .//val/common/val.h:21:0,
                 from .//val/common/val_target.h:21,
                 from ./BUILD/platform/tgt_dev_apis_tfm_an521/targetConfigGen.c:1:
.//platform/targets/tgt_dev_apis_tfm_an521/nspe/common/pal_common.h:33:29: note: previous declaration of ‘addr_t’ was here
 typedef uint32_t            addr_t;
                             ^~~~~~
Failed to compile targetConfigGen.c
make: *** [tools/makefiles/Makefile:35: target_cfg] Error 1
