### PR TITLE
Initializing status buffer state value to TEST_FAIL in test_init

### DIFF
--- a/api-tests/val/common/val_target.c
+++ b/api-tests/val/common/val_target.c
@@ -53,7 +53,7 @@ STATIC_DECLARE val_status_t val_target_cfg_get_next(void **blob)
        if ((hdr->version != 1) || (hdr->size == 0))
        {
             val_print(PRINT_ERROR, "Target config database Error. \n", 0);
-            return status;
+            return VAL_STATUS_ERROR;
         }
         hdr++;
         *blob = hdr;  // skip the header. start with the first record.

--- a/api-tests/val/nspe/val_framework.c
+++ b/api-tests/val/nspe/val_framework.c
@@ -430,7 +430,7 @@ void val_test_init(uint32_t test_num, char8_t *desc, uint32_t test_bitfield)
    miscellaneous_desc_t *misc_desc;
 
    /*global init*/
-   g_status_buffer.state   = 0;
+   g_status_buffer.state   = TEST_FAIL;
    g_status_buffer.status  = VAL_STATUS_INVALID;
 
    val_print(PRINT_ALWAYS, "\nTEST: %d | DESCRIPTION: ", test_num);


### PR DESCRIPTION
Change-Id: Ide752d9e5b01c86a3f51673e4aec5e19914991cd

Changes:
1) Initializing the default value of  State variable to  TEST_FAIL. 
    Currently if test_init fails, the test execution is skipped, but due to incorrect value of state , test is marked as pass in test results . 




@prasanth-pulla @gowthamsiddarthd @jaypit02 
Please review