### PR TITLE
Zero uninitialized variables before use

### DIFF
--- a/api-tests/dev_apis/crypto/test_c005/test_c005.c
+++ b/api-tests/dev_apis/crypto/test_c005/test_c005.c
@@ -121,6 +121,8 @@ int32_t psa_destroy_key_test(security_t caller)
         TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(9));
 
         /* Get basic metadata about a key */
+        key_type = 0;
+        bits = 0;
         status = val->crypto_function(VAL_CRYPTO_GET_KEY_INFORMATION, check1[i].key_handle,
                                       &key_type, &bits);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(10));

--- a/api-tests/dev_apis/crypto/test_c012/test_c012.c
+++ b/api-tests/dev_apis/crypto/test_c012/test_c012.c
@@ -35,7 +35,7 @@ int32_t psa_hash_update_test(security_t caller)
 {
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);
@@ -69,7 +69,7 @@ int32_t psa_hash_update_test(security_t caller)
 
 int32_t psa_hash_update_invalid_handle(security_t caller)
 {
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
     uint8_t                 input[] = "Hello World";
     size_t                  input_length = sizeof(input)/sizeof(input[0]);
     int32_t                 status;
@@ -99,7 +99,7 @@ int32_t psa_hash_update_invalid_handle(security_t caller)
 
 int32_t psa_hash_update_with_completed_handle(security_t caller)
 {
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
     uint8_t                 input[] = {0xbd};
     size_t                  input_length = sizeof(input)/sizeof(input[0]);
     psa_algorithm_t         alg = PSA_ALG_SHA_256;

--- a/api-tests/dev_apis/crypto/test_c013/test_c013.c
+++ b/api-tests/dev_apis/crypto/test_c013/test_c013.c
@@ -34,7 +34,7 @@ int32_t psa_hash_verify_test(security_t caller)
 {
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
     const char              *hash;
 
     /* Initialize the PSA crypto library*/
@@ -81,7 +81,7 @@ int32_t psa_hash_verify_test(security_t caller)
 
 int32_t psa_hash_verify_inactive_operation_handle(security_t caller)
 {
-    psa_hash_operation_t    operation, invalid_operation;
+    psa_hash_operation_t    operation = {0} , invalid_operation = {0};
     char                    input = 0xbd;
     size_t                  input_length = 1;
     psa_algorithm_t         alg = PSA_ALG_SHA_256;

--- a/api-tests/dev_apis/crypto/test_c014/test_c014.c
+++ b/api-tests/dev_apis/crypto/test_c014/test_c014.c
@@ -35,7 +35,7 @@ int32_t psa_hash_finish_test(security_t caller)
 {
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
     const char              *expected_hash;
     char                    hash[HASH_64B];
     size_t                  hash_length, hash_size = sizeof(hash)/sizeof(hash[0]);
@@ -96,7 +96,7 @@ int32_t psa_hash_finish_test(security_t caller)
 
 int32_t psa_hash_finish_inactive_operation_handle(security_t caller)
 {
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
     char                    input = 0xbd;
     size_t                  input_length = 1;
     psa_algorithm_t         alg = PSA_ALG_SHA_256;
@@ -143,7 +143,7 @@ int32_t psa_hash_finish_inactive_operation_handle(security_t caller)
 
 int32_t psa_hash_finish_invalid_hash_buffer_size(security_t caller)
 {
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
     char                    input = 0xbd;
     size_t                  input_length = 1;
     psa_algorithm_t         alg = PSA_ALG_SHA_256;

--- a/api-tests/dev_apis/crypto/test_c015/test_c015.c
+++ b/api-tests/dev_apis/crypto/test_c015/test_c015.c
@@ -34,7 +34,7 @@ int32_t psa_hash_abort_test(security_t caller)
 {
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);
@@ -68,7 +68,7 @@ int32_t psa_hash_abort_test(security_t caller)
 
 int32_t psa_hash_abort_before_operation_finish(security_t caller)
 {
-    psa_hash_operation_t    operation;
+    psa_hash_operation_t    operation = {0};
     char                    input = 0xbd;
     size_t                  input_length = 1;
     psa_algorithm_t         alg = PSA_ALG_SHA_256;

--- a/api-tests/dev_apis/crypto/test_c027/test_c027.c
+++ b/api-tests/dev_apis/crypto/test_c027/test_c027.c
@@ -37,7 +37,7 @@ int32_t psa_mac_update_test(security_t caller)
     int32_t             i, status;
     size_t              length;
     psa_key_policy_t    policy;
-    psa_mac_operation_t operation;
+    psa_mac_operation_t operation = {0};
 
     memset(data, 0, sizeof(data));
 

--- a/api-tests/dev_apis/crypto/test_c028/test_c028.c
+++ b/api-tests/dev_apis/crypto/test_c028/test_c028.c
@@ -35,8 +35,8 @@ int32_t psa_mac_sign_finish_test(security_t caller)
     int                 num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t             i, status;
     size_t              length;
-    psa_key_policy_t    policy;
-    psa_mac_operation_t operation;
+    psa_key_policy_t    policy = {0};
+    psa_mac_operation_t operation = {0};
 
     memset(data, 0, sizeof(data));
 

--- a/api-tests/dev_apis/crypto/test_c030/test_c030.c
+++ b/api-tests/dev_apis/crypto/test_c030/test_c030.c
@@ -33,8 +33,8 @@ int32_t psa_mac_verify_finish_test(security_t caller)
 {
     int                 num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t             i, status;
-    psa_key_policy_t    policy;
-    psa_mac_operation_t operation;
+    psa_key_policy_t    policy = {0};
+    psa_mac_operation_t operation = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);

--- a/api-tests/dev_apis/crypto/test_c031/test_c031.c
+++ b/api-tests/dev_apis/crypto/test_c031/test_c031.c
@@ -35,8 +35,8 @@ int32_t psa_mac_abort_test(security_t caller)
 {
     int                 num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t             i, status;
-    psa_key_policy_t    policy;
-    psa_mac_operation_t operation;
+    psa_key_policy_t    policy = {0};
+    psa_mac_operation_t operation = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);
@@ -93,12 +93,12 @@ int32_t psa_mac_abort_test(security_t caller)
 int32_t psa_mac_abort_before_finish_test(security_t caller)
 {
     size_t              length;
-    psa_key_policy_t    policy;
+    psa_key_policy_t    policy = {0};
     psa_algorithm_t     key_alg = PSA_ALG_CMAC;
     psa_key_usage_t     usage = PSA_KEY_USAGE_SIGN;
     psa_key_handle_t    key_handle = 10;
     psa_key_type_t      key_type = PSA_KEY_TYPE_AES;
-    psa_mac_operation_t operation;
+    psa_mac_operation_t operation = {0};
     uint8_t             key_data[] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab, 0xf7,
                                       0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
     uint8_t             input_data[] = {0x48, 0x69, 0x20, 0x54, 0x68, 0x65, 0x72, 0x65};

--- a/api-tests/dev_apis/crypto/test_c032/test_c032.c
+++ b/api-tests/dev_apis/crypto/test_c032/test_c032.c
@@ -29,14 +29,15 @@ client_test_t test_c032_crypto_list[] = {
 };
 
 static int                     g_test_count = 1;
-static psa_cipher_operation_t  operation;
+static psa_cipher_operation_t  operation = {0};
 
 int32_t psa_cipher_encrypt_setup_test(security_t caller)
 {
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
     const uint8_t           *key_data;
-    psa_key_policy_t        policy;
+    psa_key_policy_t        policy = {0};
+    memset(&operation, 0, sizeof( operation));
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);
@@ -122,7 +123,7 @@ int32_t psa_cipher_encrypt_setup_negative_test(security_t caller)
 {
     int                     num_checks = sizeof(check2)/sizeof(check2[0]);
     int32_t                 i, status;
-    psa_key_policy_t        policy;
+    psa_key_policy_t        policy = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);
@@ -152,6 +153,7 @@ int32_t psa_cipher_encrypt_setup_negative_test(security_t caller)
 
         val->print(PRINT_TEST, "[Check %d] Test psa_cipher_encrypt_setup - Zero as key handle\n",
                                                                                    g_test_count++);
+        memset(&operation, 0, sizeof( operation));
         /* Set the key for a multipart symmetric encryption operation */
         status = val->crypto_function(VAL_CRYPTO_CIPHER_ENCRYPT_SETUP, &operation,
                     0, check2[i].key_alg);
@@ -169,6 +171,7 @@ int32_t psa_cipher_encrypt_setup_negative_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         /* Set the key for a multipart symmetric encryption operation */
+        memset(&operation, 0, sizeof( operation));
         status = val->crypto_function(VAL_CRYPTO_CIPHER_ENCRYPT_SETUP, &operation,
                     check2[i].key_handle, check2[i].key_alg);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_EMPTY_SLOT, TEST_CHECKPOINT_NUM(7));

--- a/api-tests/dev_apis/crypto/test_c033/test_c033.c
+++ b/api-tests/dev_apis/crypto/test_c033/test_c033.c
@@ -29,7 +29,7 @@ client_test_t test_c033_crypto_list[] = {
 };
 
 static int                     g_test_count = 1;
-static psa_cipher_operation_t  operation;
+static psa_cipher_operation_t  operation = {0};
 
 int32_t psa_cipher_decrypt_setup_test(security_t caller)
 {
@@ -46,6 +46,7 @@ int32_t psa_cipher_decrypt_setup_test(security_t caller)
     {
         val->print(PRINT_TEST, "[Check %d] ", g_test_count++);
         val->print(PRINT_TEST, check1[i].test_desc, 0);
+        memset(&operation, 0, sizeof( operation));
 
         /* Initialize a key policy structure to a default that forbids all
          * usage of the key
@@ -106,6 +107,7 @@ int32_t psa_cipher_decrypt_setup_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         /* Set the key for a multipart symmetric decryption operation */
+        memset(&operation, 0, sizeof( operation));
         status = val->crypto_function(VAL_CRYPTO_CIPHER_DECRYPT_SETUP, &operation,
                     check1[i].key_handle, check1[i].key_alg);
         TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(6));
@@ -130,6 +132,7 @@ int32_t psa_cipher_decrypt_setup_negative_test(security_t caller)
 
     for (i = 0; i < num_checks; i++)
     {
+        memset(&operation, 0, sizeof( operation));
         /* Initialize a key policy structure to a default that forbids all
          * usage of the key
          */
@@ -146,6 +149,7 @@ int32_t psa_cipher_decrypt_setup_negative_test(security_t caller)
         val->print(PRINT_TEST, "[Check %d] Test psa_cipher_decrypt_setup - Invalid key handle\n",
                                                                                    g_test_count++);
         /* Set the key for a multipart symmetric decryption operation */
+        memset(&operation, 0, sizeof( operation));
         status = val->crypto_function(VAL_CRYPTO_CIPHER_DECRYPT_SETUP, &operation,
                     check2[i].key_handle, check2[i].key_alg);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(3));
@@ -153,6 +157,7 @@ int32_t psa_cipher_decrypt_setup_negative_test(security_t caller)
         val->print(PRINT_TEST, "[Check %d] Test psa_cipher_decrypt_setup - Zero as key handle\n",
                                                                                    g_test_count++);
         /* Set the key for a multipart symmetric decryption operation */
+        memset(&operation, 0, sizeof( operation));
         status = val->crypto_function(VAL_CRYPTO_CIPHER_DECRYPT_SETUP, &operation,
                     0, check2[i].key_alg);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(4));
@@ -169,6 +174,7 @@ int32_t psa_cipher_decrypt_setup_negative_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         /* Set the key for a multipart symmetric decryption operation */
+        memset(&operation, 0, sizeof( operation));
         status = val->crypto_function(VAL_CRYPTO_CIPHER_DECRYPT_SETUP, &operation,
                     check2[i].key_handle, check2[i].key_alg);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_EMPTY_SLOT, TEST_CHECKPOINT_NUM(7));

--- a/api-tests/dev_apis/crypto/test_c035/test_c035.c
+++ b/api-tests/dev_apis/crypto/test_c035/test_c035.c
@@ -34,8 +34,8 @@ int32_t psa_cipher_set_iv_test(security_t caller)
 {
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
-    psa_key_policy_t        policy;
-    psa_cipher_operation_t  operation;
+    psa_key_policy_t        policy = {0};;
+    psa_cipher_operation_t  operation = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);

--- a/api-tests/dev_apis/crypto/test_c036/test_c036.c
+++ b/api-tests/dev_apis/crypto/test_c036/test_c036.c
@@ -30,7 +30,7 @@ client_test_t test_c036_crypto_list[] = {
 
 static int                     g_test_count = 1;
 static uint8_t                 output[SIZE_32B];
-static psa_cipher_operation_t  operation;
+static psa_cipher_operation_t  operation = {0};
 
 int32_t psa_cipher_update_test(security_t caller)
 {
@@ -46,6 +46,7 @@ int32_t psa_cipher_update_test(security_t caller)
 
     for (i = 0; i < num_checks; i++)
     {
+        memset(&operation, 0, sizeof( operation));
         val->print(PRINT_TEST, "[Check %d] ", g_test_count++);
         val->print(PRINT_TEST, check1[i].test_desc, 0);
 
@@ -80,12 +81,14 @@ int32_t psa_cipher_update_test(security_t caller)
         if (check1[i].usage == PSA_KEY_USAGE_ENCRYPT)
         {
             /* Set the key for a multipart symmetric encryption operation */
+            memset(&operation, 0, sizeof( operation));
             status = val->crypto_function(VAL_CRYPTO_CIPHER_ENCRYPT_SETUP, &operation,
                         check1[i].key_handle, check1[i].key_alg);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
         }
         else if (check1[i].usage == PSA_KEY_USAGE_DECRYPT)
         {
+            memset(&operation, 0, sizeof( operation));
             status = val->crypto_function(VAL_CRYPTO_CIPHER_DECRYPT_SETUP, &operation,
                         check1[i].key_handle, check1[i].key_alg);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));

--- a/api-tests/dev_apis/crypto/test_c037/test_c037.c
+++ b/api-tests/dev_apis/crypto/test_c037/test_c037.c
@@ -39,7 +39,7 @@ int32_t psa_cipher_finish_test(security_t caller)
     int32_t                 i, status;
     size_t                  update_length, finish_length;
     psa_key_policy_t        policy;
-    psa_cipher_operation_t  operation, invalid_operation;
+    psa_cipher_operation_t  operation = {0}, invalid_operation = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);

--- a/api-tests/dev_apis/crypto/test_c038/test_c038.c
+++ b/api-tests/dev_apis/crypto/test_c038/test_c038.c
@@ -36,7 +36,7 @@ int32_t psa_cipher_abort_test(security_t caller)
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
     psa_key_policy_t        policy;
-    psa_cipher_operation_t  operation;
+    psa_cipher_operation_t  operation = {0};
 
     /* Initialize the PSA crypto library*/
     status = val->crypto_function(VAL_CRYPTO_INIT);
@@ -109,7 +109,7 @@ int32_t psa_cipher_abort_before_update_test(security_t caller)
     psa_key_usage_t         usage = PSA_KEY_USAGE_ENCRYPT;
     psa_key_handle_t        key_handle = 13;
     psa_key_type_t          key_type = PSA_KEY_TYPE_AES;
-    psa_cipher_operation_t  operation;
+    psa_cipher_operation_t  operation = {0};
     uint8_t                 key_data[] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6, 0xab,
                                           0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
     uint8_t                 input[] = {0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9,


### PR DESCRIPTION
in cases need to init the values, initialize the variables to 0.