### PR TITLE
add destroy key after import

### DIFF
--- a/api-tests/dev_apis/crypto/test_c042/test_c042.c
+++ b/api-tests/dev_apis/crypto/test_c042/test_c042.c
@@ -114,6 +114,10 @@ int32_t psa_asymmetric_verify_test(security_t caller)
                     check1[i].key_alg, check1[i].input, check1[i].input_length,
                     check1[i].signature, check1[i].signature_size);
         TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(6));
+
+        /* Destroy a key and restore the slot to its default state */
+        status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7)); 
     }
 
     return VAL_STATUS_SUCCESS;


### PR DESCRIPTION
This test allocating and importing tests multiple times, but it never destroys the key.
this causing a memory leak. and an out of heap memory error.