### PR TITLE
change return value to success its test 09 (bug fix)

### DIFF
--- a/api-tests/dev_apis/internal_trusted_storage/test_s009/test_its_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s009/test_its_data.h
@@ -33,16 +33,16 @@ static const test_data s009_data[] = {
  0, 0 /* This is dummy for index0 */
 },
 {
- VAL_ITS_SET, PSA_ITS_ERROR_INVALID_ARGUMENTS /* Call set API with 0 write buffer */
+ VAL_ITS_SET, PSA_ITS_SUCCESS /* Call set API with 0 write buffer */
 },
 {
- VAL_ITS_GET_INFO, PSA_ITS_ERROR_UID_NOT_FOUND /* Call to get_info API should fail */
+ VAL_ITS_GET_INFO, PSA_ITS_SUCCESS /* Call to get_info API should fail */
 },
 {
  VAL_ITS_SET, PSA_ITS_SUCCESS /* Create storage of zero size */
 },
 {
- VAL_ITS_SET, PSA_ITS_ERROR_INVALID_ARGUMENTS /* Try to set 0 buffer for previous created storage */
+ VAL_ITS_SET, PSA_ITS_SUCCESS /* Try to set 0 buffer for previous created storage */
 },
 {
  VAL_ITS_GET_INFO, PSA_ITS_SUCCESS /* Call get_info API to check data size */
@@ -51,7 +51,7 @@ static const test_data s009_data[] = {
  0, 0 /* This is dummy for index6 */
 },
 {
- VAL_ITS_GET, PSA_ITS_ERROR_INVALID_ARGUMENTS /* Call get API with 0 read buffer */
+ VAL_ITS_GET, PSA_ITS_SUCCESS /* Call get API with 0 read buffer */
 },
 {
  VAL_ITS_SET, PSA_ITS_SUCCESS /* Increase the asset size */

--- a/api-tests/dev_apis/internal_trusted_storage/test_s009/test_ps_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s009/test_ps_data.h
@@ -33,16 +33,16 @@ static const test_data s009_data[] = {
  0, 0 /* This is dummy for index0 */
 },
 {
- VAL_PS_SET, PSA_PS_ERROR_INVALID_ARGUMENT /* Call set API with 0 write buffer */
+ VAL_PS_SET, PSA_PS_SUCCESS /* Call set API with 0 write buffer */
 },
 {
- VAL_PS_GET_INFO, PSA_PS_ERROR_UID_NOT_FOUND /* Call to get_info API should fail */
+ VAL_PS_GET_INFO, PSA_PS_SUCCESS /* Call to get_info API should fail */
 },
 {
  VAL_PS_SET, PSA_PS_SUCCESS /* Create storage of zero size */
 },
 {
- VAL_PS_SET, PSA_PS_ERROR_INVALID_ARGUMENT /* Try to set 0 buffer for previous created storage */
+ VAL_PS_SET, PSA_PS_SUCCESS /* Try to set 0 buffer for previous created storage */
 },
 {
  VAL_PS_GET_INFO, PSA_PS_SUCCESS /* Call get_info API to check data size */
@@ -51,7 +51,7 @@ static const test_data s009_data[] = {
  0, 0 /* This is dummy for index6 */
 },
 {
- VAL_PS_GET, PSA_PS_ERROR_INVALID_ARGUMENT /* Call get API with 0 read buffer */
+ VAL_PS_GET, PSA_PS_SUCCESS /* Call get API with 0 read buffer */
 },
 {
  VAL_PS_SET, PSA_PS_SUCCESS /* Increase the asset size */


### PR DESCRIPTION
according to the protected storage PSA spec it is allowed to set a buffer with a zero size. in that case, the buffer may be NULL.

https://github.com/ARMmbed/psa_trusted_storage_api/blob/master/docs/PSATrustedStorageBody.md

this action (calling to set with a zero size) will have the same effect as "touch" in Linux will reserve an empty key.

for more information please contact David Saada (David.saada@arm.com)