### PR TITLE
Prevent passing null buffer with non-zero size

### DIFF
--- a/api-tests/dev_apis/crypto/test_c024/test_c024.c
+++ b/api-tests/dev_apis/crypto/test_c024/test_c024.c
@@ -90,12 +90,18 @@ int32_t psa_aead_encrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].nonce, check1[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check1[i].nonce_length = 0;
+        }
         else
             nonce = check1[i].nonce;
 
         if (is_buffer_empty(check1[i].additional_data, check1[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check1[i].additional_data_length = 0;
+        }
         else
             additional_data = check1[i].additional_data;
 
@@ -152,12 +158,18 @@ int32_t psa_aead_encrypt_negative_test(security_t caller)
                                                                           check2[i].key_alg);
 
         if (is_buffer_empty(check2[i].nonce, check2[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check2[i].nonce_length = 0;
+        }
         else
             nonce = check2[i].nonce;
 
         if (is_buffer_empty(check2[i].additional_data, check2[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check2[i].additional_data_length = 0;
+        }
         else
             additional_data = check2[i].additional_data;
 

--- a/api-tests/dev_apis/crypto/test_c025/test_c025.c
+++ b/api-tests/dev_apis/crypto/test_c025/test_c025.c
@@ -89,12 +89,18 @@ int32_t psa_aead_decrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].nonce, check1[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check1[i].nonce_length = 0;
+        }
         else
             nonce = check1[i].nonce;
 
         if (is_buffer_empty(check1[i].additional_data, check1[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check1[i].additional_data_length = 0;
+        }
         else
             additional_data = check1[i].additional_data;
 
@@ -149,12 +155,18 @@ int32_t psa_aead_decrypt_negative_test(security_t caller)
                                                                           check2[i].key_alg);
 
         if (is_buffer_empty(check2[i].nonce, check2[i].nonce_length) == TRUE)
+        {
             nonce = NULL;
+            check2[i].nonce_length = 0;
+        }
         else
             nonce = check2[i].nonce;
 
         if (is_buffer_empty(check2[i].additional_data, check2[i].additional_data_length) == TRUE)
+        {
             additional_data = NULL;
+            check2[i].additional_data_length = 0;
+        }
         else
             additional_data = check2[i].additional_data;
 

--- a/api-tests/dev_apis/crypto/test_c039/test_c039.c
+++ b/api-tests/dev_apis/crypto/test_c039/test_c039.c
@@ -128,7 +128,10 @@ int32_t psa_asymmetric_encrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 
@@ -223,7 +226,10 @@ int32_t psa_asymmetric_encrypt_negative_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 

--- a/api-tests/dev_apis/crypto/test_c040/test_c040.c
+++ b/api-tests/dev_apis/crypto/test_c040/test_c040.c
@@ -128,7 +128,10 @@ int32_t psa_asymmetric_decrypt_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 
@@ -209,7 +212,10 @@ int32_t psa_asymmetric_decrypt_negative_test(security_t caller)
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         if (is_buffer_empty(check1[i].salt, check1[i].salt_length) == TRUE)
+        {
             salt = NULL;
+            check1[i].salt_length = 0;
+        }
         else
             salt = check1[i].salt;
 


### PR DESCRIPTION
Function `is_buffer_empty` tests if all data in the buffer is `0`. If it is `0` then it sets the buffer to `NULL` but does not change the buffer size eventually sending to the functions a null pointer for buffer with a size greater than `0`. This PR sets the size to `0` when `is_buffer_empty` is true thus preventing passing a NULL buffer with a non-zero size.