### PR TITLE
Test#14: Fixed the length of read and write buffer

### DIFF
--- a/api-tests/dev_apis/protected_storage/test_p014/test_p014.c
+++ b/api-tests/dev_apis/protected_storage/test_p014/test_p014.c
@@ -48,7 +48,7 @@ static int32_t psa_sst_optional_api_not_supported()
 
     /* Create a valid storage using set API */
     val->print(PRINT_TEST, "[Check 2] Create valid storage with set API\n", 0);
-    status = SST_FUNCTION(p014_data[3].api, p_uid, TEST_BUFF_SIZE, write_buff, 0);
+    status = SST_FUNCTION(p014_data[3].api, p_uid, TEST_BUFF_SIZE/4, write_buff, 0);
     TEST_ASSERT_EQUAL(status, p014_data[3].status, TEST_CHECKPOINT_NUM(3));
 
     /* Partial data write with set_extended API should fail */
@@ -58,7 +58,7 @@ static int32_t psa_sst_optional_api_not_supported()
 
     /* Call the get function to match the data */
     val->print(PRINT_TEST, "[Check 4] Verify data is unchanged\n", 0);
-    status = SST_FUNCTION(p014_data[5].api, p_uid, 0, TEST_BUFF_SIZE, read_buff);
+    status = SST_FUNCTION(p014_data[5].api, p_uid, 0, TEST_BUFF_SIZE/4, read_buff);
     TEST_ASSERT_EQUAL(status, p014_data[5].status, TEST_CHECKPOINT_NUM(5));
     TEST_ASSERT_MEMCMP(read_buff, write_buff, TEST_BUFF_SIZE/4, TEST_CHECKPOINT_NUM(6));
 


### PR DESCRIPTION
Fix for #81: 
The read and write buffer are define of 4 octet length, but the read length passed in psa_get API was 16 octets, which resulted in secure fault.