### PR TITLE
Add TF-M Musca-B1 support for Developer API tests

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/Makefile
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/Makefile
@@ -1,0 +1,159 @@
+# * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *  http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#**/
+
+include $(SOURCE)/tools/makefiles/toolchain.mk
+
+# Make variables to select correct instances of PAL files
+
+## PSA_IPC_IMPLEMENTED must be true for IPC SUITE
+PSA_IPC_IMPLEMENTED:=0
+
+## PSA_CRYPTO_IMPLEMENTED must be true for CRYPTO SUITE
+PSA_CRYPTO_IMPLEMENTED:=1
+
+## PSA_PROTECTED_STORAGE_IMPLEMENTED must be true for PROTECTED_STORAGE SUITE
+PSA_PROTECTED_STORAGE_IMPLEMENTED:=1
+
+## PSA_INTERNAL_TRUSTED_STORAGE_IMPLEMENTED must be true for INTERNAL_TRUSTED_STORAGE SUITE
+PSA_INTERNAL_TRUSTED_STORAGE_IMPLEMENTED:=0
+
+## PSA_INITIAL_ATTESTATION_IMPLEMENTED must be true for INITIAL_ATTESTATION SUITE
+PSA_INITIAL_ATTESTATION_IMPLEMENTED:=1
+
+# Make variables holding NSPE/SPE source files
+
+## PAL C source files part of NSPE library
+SRC_C_NSPE=
+
+## PAL ASM source files part of NSPE library
+SRC_ASM_NSPE=
+
+## PAL C source files part of SPE library - driver partition
+SRC_C_DRIVER_SP=
+
+## PAL ASM source files part of SPE library - driver partition
+SRC_ASM_DRIVER_SP=
+
+ifeq (${PSA_IPC_IMPLEMENTED},1)
+# When PSA_IPC_IMPLEMENTED=1, driver functionalities are implemented as RoT-services
+# and secure and non-secure clients will call to these RoT-services to get appropriate driver services.
+SRC_C_NSPE += pal_client_api_intf.c
+SRC_C_NSPE += pal_driver_ipc_intf.c
+
+# Driver files will be compiled as part of driver partition
+SRC_C_DRIVER_SP += pal_driver_intf.c pal_nvmem.c pal_uart.c pal_wd_cmsdk.c
+else
+
+# When PSA_IPC_IMPLEMENTED=0, driver files will be compiled as part of NSPE
+SRC_C_NSPE += pal_client_api_empty_intf.c
+SRC_C_NSPE += pal_driver_ns_intf.c pal_nvmem.c pal_uart.c pal_wd_cmsdk.c
+endif
+
+ifeq (${PSA_CRYPTO_IMPLEMENTED},1)
+SRC_C_NSPE += pal_crypto_intf.c
+else
+SRC_C_NSPE += pal_crypto_empty_intf.c
+endif
+
+ifeq (${PSA_PROTECTED_STORAGE_IMPLEMENTED},1)
+SRC_C_NSPE += pal_protected_storage_intf.c
+else
+SRC_C_NSPE += pal_protected_storage_empty_intf.c
+endif
+
+ifeq (${PSA_INTERNAL_TRUSTED_STORAGE_IMPLEMENTED},1)
+SRC_C_NSPE += pal_internal_trusted_storage_intf.c
+else
+SRC_C_NSPE += pal_internal_trusted_storage_empty_intf.c
+endif
+
+ifeq (${PSA_INITIAL_ATTESTATION_IMPLEMENTED},1)
+SRC_C_NSPE += pal_attestation_intf.c
+SRC_C_NSPE += pal_attestation_eat.c
+else
+SRC_C_NSPE += pal_attestation_empty_intf.c
+endif
+
+INCLUDE= -I$(SOURCE)/platform/targets/$(TARGET)/nspe \
+         -I$(SOURCE)/platform/targets/$(TARGET)/spe \
+         -I$(BUILD)/platform/$(TARGET)/ \
+         -I$(SOURCE)/platform/drivers/uart/pl011 \
+         -I$(SOURCE)/platform/drivers/nvmem/ \
+         -I$(SOURCE)/platform/drivers/watchdog/cmsdk \
+         -I$(SOURCE)/platform/targets/$(TARGET)/nspe/common \
+         -I$(SOURCE)/platform/targets/$(TARGET)/nspe/crypto \
+         -I$(SOURCE)/platform/targets/$(TARGET)/nspe/initial_attestation \
+         -I$(SOURCE)/platform/targets/$(TARGET)/nspe/initial_attestation/ext/inc \
+         -I$(SOURCE)/platform/targets/$(TARGET)/nspe/internal_trusted_storage \
+         -I$(SOURCE)/platform/targets/$(TARGET)/nspe/protected_storage
+
+VPATH=$(SOURCE)/platform/targets/$(TARGET)/: \
+      $(SOURCE)/platform/targets/$(TARGET)/spe: \
+      $(SOURCE)/platform/targets/$(TARGET)/nspe: \
+      $(SOURCE)/platform/drivers/uart/pl011: \
+      $(SOURCE)/platform/drivers/nvmem: \
+      $(SOURCE)/platform/drivers/watchdog/cmsdk: \
+      $(SOURCE)/platform/targets/$(TARGET)/nspe/common: \
+      $(SOURCE)/platform/targets/$(TARGET)/nspe/crypto: \
+      $(SOURCE)/platform/targets/$(TARGET)/nspe/initial_attestation: \
+      $(SOURCE)/platform/targets/$(TARGET)/nspe/initial_attestation/ext/src: \
+      $(SOURCE)/platform/targets/$(TARGET)/nspe/internal_trusted_storage: \
+      $(SOURCE)/platform/targets/$(TARGET)/nspe/protected_storage: \
+
+all: build
+
+ifeq (${PSA_IPC_IMPLEMENTED},1)
+build: mkdir build_nspe_pal build_spe_pal
+else
+build: mkdir build_nspe_pal
+endif
+
+mkdir:
+	@mkdir -p $(BUILD)/platform/nspe/
+	@mkdir -p $(BUILD)/platform/spe/
+
+# BUILD NSPE PAL
+build_nspe_pal: build_c_nspe build_asm_nspe pal_nspe.a
+
+build_c_nspe: $(SRC_C_NSPE:%.c=$(BUILD)/platform/nspe/%.o)
+build_asm_nspe: $(SRC_ASM_NSPE:%.s=$(BUILD)/platform/nspe/%.o)
+
+$(BUILD)/platform/nspe/%.o : %.c
+	$(CC) $(PAL_CDEFS) $(INCLUDE) -o $@ -c $<
+
+$(BUILD)/platform/nspe/%.o : %.s
+	$(AS) $(INCLUDE) -o $@ $<
+
+pal_nspe.a:
+	$(AR) $(AR_OPTIONS) $(BUILD)/platform/pal_nspe.a $(BUILD)/platform/nspe/*.o
+
+# BUILD SPE PAL
+build_spe_pal: build_driver_sp
+
+build_driver_sp: build_c_driver_sp build_asm_driver_sp
+
+build_c_driver_sp: $(SRC_C_DRIVER_SP:%.c=$(BUILD)/platform/spe/%_driver_sp.o)
+build_asm_driver_sp: $(SRC_ASM_DRIVER_SP:%.s=$(BUILD)/platform/spe/%_driver_sp.o)
+
+# Generated %_driver_sp.o(s) are used in spbuild.mk to create final driver_partition.a
+$(BUILD)/platform/spe/%_driver_sp.o : %.c
+	$(CC) $(INCLUDE) -DSPE_BUILD -o $@ -c $<
+
+$(BUILD)/platform/spe/%_driver_sp.o : %.s
+	$(AS) $(INCLUDE) -o $@ $<
+
+clean:
+	@rm -rf $(BUILD)/platform/nspe/* $(BUILD)/platform/spe/*.a

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/manifests/common/driver_partition_psa.json
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/manifests/common/driver_partition_psa.json
@@ -1,0 +1,81 @@
+{
+  "psa_framework_version": 1.0,
+  "name": "DRIVER_PARTITION",
+  "type": "PSA-ROT",
+  "priority": "NORMAL",
+  "id": "0x00000003",
+  "description": "Implements device services such print, flash read/write,. etc.",
+  "entry_point": "driver_main",
+  "stack_size": "0x400",
+  "heap_size": "0x100",
+  "services": [{
+      "name": "DRIVER_UART_SID",
+      "sid": "0x0000FC01",
+      "signal": "DRIVER_UART_SIG",
+      "non_secure_clients": true,
+      "minor_version": 1,
+      "minor_policy": "RELAXED"
+    },
+    {
+      "name": "DRIVER_WATCHDOG_SID",
+      "sid": "0x0000FC02",
+      "signal": "DRIVER_WATCHDOG_SIG",
+      "non_secure_clients": true,
+      "minor_version": 1,
+      "minor_policy": "RELAXED"
+    },
+    {
+      "name": "DRIVER_NVMEM_SID",
+      "sid": "0x0000FC03",
+      "signal": "DRIVER_NVMEM_SIG",
+      "non_secure_clients": true,
+      "minor_version": 1,
+      "minor_policy": "RELAXED"
+    },
+    {
+      "name": "TEST_INTR_SID",
+      "sid": "0x0000FC04",
+      "signal": "TEST_INTR_SIG",
+      "non_secure_clients": true,
+      "minor_version": 1,
+      "minor_policy": "RELAXED"
+    }
+  ],
+  "mmio_regions" : [
+    {
+      "name": "UART_REGION",
+      "base": "0x40004000",
+      "size": "0x1000",
+      "permission": "READ-WRITE"
+    },
+    {
+      "name": "WATCHDOG_REGION",
+      "base": "0x40008000",
+      "size": "0x1000",
+      "permission": "READ-WRITE"
+    },
+    {
+      "name": "NVMEM_REGION",
+      "base": "0x2002F000",
+      "size": "0x400",
+      "permission": "READ-WRITE"
+    },
+    {
+      "name": "DRIVER_PARTITION_MMIO",
+      "base": "0x200AF040",
+      "size": "0x20",
+      "permission": "READ-WRITE"
+    }
+  ],
+  "irqs": [
+    {
+       "signal": "DRIVER_UART_INTR_SIG",
+       "line_num": 17
+    }
+  ],
+  "linker_pattern": {
+    "object_list": [
+    "driver_partition.a"
+    ]
+  }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/manifests/ipc/client_partition_psa.json
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/manifests/ipc/client_partition_psa.json
@@ -1,0 +1,44 @@
+{
+  "psa_framework_version": 1.0,
+  "name": "CLIENT_PARTITION",
+  "type": "APPLICATION-ROT",
+  "priority": "NORMAL",
+  "id": "0x00000001",
+  "description": "Client partition executing client test func from SPE",
+  "entry_point": "client_main",
+  "stack_size": "0x400",
+  "heap_size": "0x100",
+  "services": [{
+      "name": "CLIENT_TEST_DISPATCHER_SID",
+      "sid": "0x0000FA01",
+      "signal": "CLIENT_TEST_DISPATCHER_SIG",
+      "non_secure_clients": true,
+      "minor_version": 1,
+      "minor_policy": "RELAXED"
+    }
+  ],
+  "dependencies": [
+    "DRIVER_UART_SID",
+    "DRIVER_NVMEM_SID",
+    "TEST_INTR_SID",
+    "SERVER_TEST_DISPATCHER_SID",
+    "SERVER_UNSPECIFED_MINOR_V_SID",
+    "SERVER_STRICT_MINOR_VERSION_SID",
+    "SERVER_RELAX_MINOR_VERSION_SID",
+    "SERVER_SECURE_CONNECT_ONLY_SID",
+    "SERVER_CONNECTION_DROP_SID"
+  ],
+  "mmio_regions" : [
+    {
+      "name": "CLIENT_PARTITION_MMIO",
+      "base": "0x200AF000",
+      "size": "0x20",
+      "permission": "READ-WRITE"
+    }
+   ],
+  "linker_pattern": {
+    "object_list": [
+    "client_partition.a"
+    ]
+  }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/manifests/ipc/server_partition_psa.json
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/manifests/ipc/server_partition_psa.json
@@ -1,0 +1,75 @@
+{
+  "psa_framework_version": 1.0,
+  "name": "SERVER_PARTITION",
+  "type": "APPLICATION-ROT",
+  "priority": "NORMAL",
+  "id": "0x00000002",
+  "description": "Server partition executing server test func",
+  "entry_point": "server_main",
+  "stack_size": "0x400",
+  "heap_size": "0x100",
+  "services": [{
+      "name": "SERVER_TEST_DISPATCHER_SID",
+      "sid": "0x0000FB01",
+      "signal": "SERVER_TEST_DISPATCHER_SIG",
+      "non_secure_clients": true,
+      "minor_version": 1,
+      "minor_policy": "RELAXED"
+    },
+    {
+      "name": "SERVER_SECURE_CONNECT_ONLY_SID",
+      "sid": "0x0000FB02",
+      "signal": "SERVER_SECURE_CONNECT_ONLY_SIG",
+      "non_secure_clients": false,
+      "minor_version": 2,
+      "minor_policy": "RELAXED"
+    },
+    {
+      "name": "SERVER_STRICT_MINOR_VERSION_SID",
+      "sid": "0x0000FB03",
+      "signal": "SERVER_STRICT_MINOR_VERSION_SIG",
+      "non_secure_clients": true,
+      "minor_version": 2,
+      "minor_policy": "STRICT"
+    },
+    {
+      "name": "SERVER_UNSPECIFED_MINOR_V_SID",
+      "sid": "0x0000FB04",
+      "signal": "SERVER_UNSPECIFED_MINOR_V_SIG",
+      "non_secure_clients": true
+    },
+    {
+      "name": "SERVER_RELAX_MINOR_VERSION_SID",
+      "sid": "0x0000FB05",
+      "signal": "SERVER_RELAX_MINOR_VERSION_SIG",
+      "non_secure_clients": true,
+      "minor_version": 2,
+      "minor_policy": "RELAXED"
+    },
+    {
+      "name": "SERVER_UNEXTERN_SID",
+      "sid": "0x0000FB06",
+      "signal": "SERVER_UNEXTERN_SIG",
+      "non_secure_clients": true,
+      "minor_version": 2,
+      "minor_policy": "RELAXED"
+    },
+    {
+      "name": "SERVER_CONNECTION_DROP_SID",
+      "sid": "0x0000FB07",
+      "signal": "SERVER_CONNECTION_DROP_SIG",
+      "non_secure_clients": true,
+      "minor_version": 2,
+      "minor_policy": "RELAXED"
+    }
+  ],
+  "dependencies": [
+    "DRIVER_UART_SID",
+    "DRIVER_NVMEM_SID"
+  ],
+  "linker_pattern": {
+    "object_list": [
+    "server_partition.a"
+    ]
+  }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_client_api_empty_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_client_api_empty_intf.c
@@ -1,0 +1,93 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+#include "pal_client_api_intf.h"
+
+/**
+ * @brief - Retrieve the version of the PSA Framework API that is implemented.
+ * This is a wrapper API for psa_framework_version API.
+ * @param    - void
+ * @return   - The PSA Framework API version.
+ */
+
+uint32_t pal_ipc_framework_version(void)
+{
+    return 0;
+}
+
+/**
+ * @brief - Retrieve the minor version of a Root of Trust Service by its SID.
+ * This is a wrapper API for the psa_version API.
+ * @param - sid The Root of Trust Service ID
+ * @return - Minor version of Root of Trust Service or PSA_VERSION_NONE if Root of Trust
+ *           Service not present on the system.
+ */
+
+uint32_t pal_ipc_version(uint32_t sid)
+{
+    return PSA_VERSION_NONE;
+}
+
+/**
+ * @brief   - Connect to given sid.
+ *            This is a wrapper API for the psa_connect API.
+ * @param   - sid : RoT service id
+ * @param   - minor_version : minor_version of RoT service
+ * @return  - psa_handle_t : return connection handle
+ */
+
+psa_handle_t pal_ipc_connect(uint32_t sid, uint32_t minor_version)
+{
+    return PSA_NULL_HANDLE;
+}
+
+/**
+ * @brief Call a connected Root of Trust Service.
+ * This is a wrapper API for the psa_call API.
+ * The caller must provide an array of ::psa_invec_t structures as the input payload.
+ *
+ * @param  -handle   Handle for the connection.
+ * @param  -in_vec   Array of psa_invec structures.
+ * @param  -in_len   Number of psa_invec structures in in_vec.
+ * @param  -out_vec  Array of psa_outvec structures for optional Root of Trust Service response.
+ * @param  -out_len  Number of psa_outvec structures in out_vec.
+ * @return -psa_status_t
+ */
+
+psa_status_t pal_ipc_call(psa_handle_t handle,
+                         const psa_invec *in_vec,
+                         size_t in_len,
+                         psa_outvec *out_vec,
+                         size_t out_len)
+{
+    return (PSA_SUCCESS - 1);
+}
+
+/**
+ * @brief Close a connection to a Root of Trust Service.
+ * This is a wrapper API for the psa_close API.
+ * Sends the PSA_IPC_DISCONNECT message to the Root of Trust Service so it can clean up resources.
+ *
+ * @param handle Handle for the connection.
+ * @return void
+ */
+
+void pal_ipc_close(psa_handle_t handle)
+{
+    return;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_client_api_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_client_api_intf.c
@@ -1,0 +1,97 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+#include "pal_client_api_intf.h"
+
+/**
+ * @brief   - Retrieve the version of the PSA Framework API that is implemented.
+ * This is a wrapper API for psa_framework_version API.
+ * @param    - void
+ * @return   - The PSA Framework API version.
+ *             Note - Return PAL_STATUS_ERROR if PSA IPC is not implemented.
+ */
+
+uint32_t pal_ipc_framework_version(void)
+{
+    return (psa_framework_version());
+}
+
+/**
+ * @brief   - Retrieve the minor version of a Root of Trust Service by its SID.
+ * This is a wrapper API for the psa_version API.
+ * @param - sid The Root of Trust Service ID
+ * @return - Minor version of Root of Trust Service or PSA_VERSION_NONE if Root of Trust
+ *           Service not present on the system.
+ *           Note - Return PAL_STATUS_ERROR if PSA IPC is not implemented.
+ */
+
+uint32_t pal_ipc_version(uint32_t sid)
+{
+    return (psa_version(sid));
+}
+
+/**
+ * @brief   - Connect to given sid.
+ *            This is a wrapper API for the psa_connect API.
+ * @param   - sid : RoT service id
+ * @param   - minor_version : minor_version of RoT service
+ * @return  - psa_handle_t : return connection handle
+ *            Note - Return PSA_NULL_HANDLE if PSA IPC is not implemented.
+ */
+
+psa_handle_t pal_ipc_connect(uint32_t sid, uint32_t minor_version)
+{
+    return (psa_connect(sid, minor_version));
+}
+
+/**
+ * @brief Call a connected Root of Trust Service.
+ * This is a wrapper API for the psa_call API.
+ * The caller must provide an array of ::psa_invec_t structures as the input payload.
+ *
+ * @param  -handle   Handle for the connection.
+ * @param  -in_vec   Array of psa_invec structures.
+ * @param  -in_len   Number of psa_invec structures in in_vec.
+ * @param  -out_vec  Array of psa_outvec structures for optional Root of Trust Service response.
+ * @param  -out_len  Number of psa_outvec structures in out_vec.
+ * @return -psa_status_t
+ *          Note - Return -1 if PSA IPC is not implemented.
+ */
+
+psa_status_t pal_ipc_call(psa_handle_t handle,
+                         const psa_invec *in_vec,
+                         size_t in_len,
+                         psa_outvec *out_vec,
+                         size_t out_len)
+{
+    return (psa_call(handle, in_vec, in_len, out_vec, out_len));
+}
+
+/**
+ * @brief Close a connection to a Root of Trust Service.
+ * This is a wrapper API for the psa_close API.
+ * Sends the PSA_IPC_DISCONNECT message to the Root of Trust Service so it can clean up resources.
+ *
+ * @param  - handle Handle for the connection.
+ * @return - void
+ */
+
+void pal_ipc_close(psa_handle_t handle)
+{
+    psa_close(handle);
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_client_api_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_client_api_intf.h
@@ -1,0 +1,32 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_CLIENT_API_H_
+#define _PAL_CLIENT_API_H_
+
+#include "pal_common.h"
+
+uint32_t pal_ipc_framework_version(void);
+uint32_t pal_ipc_version(uint32_t sid);
+psa_handle_t pal_ipc_connect(uint32_t sid, uint32_t minor_version);
+psa_status_t pal_ipc_call(psa_handle_t handle,
+                      const psa_invec *in_vec,
+                      size_t in_len,
+                      psa_outvec *out_vec,
+                      size_t out_len);
+void pal_ipc_close(psa_handle_t handle);
+#endif /* _PAL_CLIENT_API_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_common.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_common.h
@@ -1,0 +1,118 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_COMMON_H_
+#define _PAL_COMMON_H_
+
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <stdarg.h>
+
+#ifndef TARGET_CFG_BUILD
+#include "pal_config.h"
+#include "pal_crypto_config.h"
+#endif
+
+/* typedef's */
+typedef uint8_t             bool_t;
+typedef uint32_t            addr_t;
+typedef uint32_t            test_id_t;
+typedef uint32_t            block_id_t;
+typedef char                char8_t;
+typedef uint32_t            cfg_id_t;
+
+#define PAL_STATUS_UNSUPPORTED_FUNC      0xFF
+
+typedef enum
+{
+    PAL_STATUS_SUCCESS = 0x0,
+    PAL_STATUS_ERROR   = 0x80
+} pal_status_t;
+
+typedef enum {
+    NVMEM_READ             = 0x1,
+    NVMEM_WRITE            = 0x2,
+} nvmem_fn_type_t;
+
+typedef struct {
+    nvmem_fn_type_t nvmem_fn_type;
+    addr_t base;
+    uint32_t offset;
+    int size;
+} nvmem_param_t;
+
+typedef enum {
+    WD_INIT_SEQ         = 0x1,
+    WD_ENABLE_SEQ       = 0x2,
+    WD_DISABLE_SEQ      = 0x3,
+    WD_STATUS_SEQ       = 0x4,
+} wd_fn_type_t;
+
+typedef enum {
+    WD_LOW_TIMEOUT      = 0x1,
+    WD_MEDIUM_TIMEOUT   = 0x2,
+    WD_HIGH_TIMEOUT     = 0x3,
+    WD_CRYPTO_TIMEOUT   = 0x4,
+} wd_timeout_type_t;
+
+typedef struct {
+    wd_fn_type_t wd_fn_type;
+    addr_t       wd_base_addr;
+    uint32_t     wd_time_us;
+    uint32_t     wd_timer_tick_us;
+} wd_param_t;
+
+typedef enum {
+    UART_INIT             = 0x1,
+    UART_PRINT            = 0x2,
+} uart_fn_type_t;
+
+/*
+ * Redefining some of the client.h elements for compilation to go through
+ * when PSA IPC APIs are not implemented.
+ */
+#if (PSA_IPC_IMPLEMENTED == 0)
+
+#ifndef PSA_VERSION_NONE
+#define PSA_VERSION_NONE            (0)
+#endif
+
+#ifndef PSA_SUCCESS
+#define PSA_SUCCESS                 (0)
+typedef int32_t psa_status_t;
+#endif
+typedef int32_t psa_handle_t;
+
+#ifndef PSA_NULL_HANDLE
+#define PSA_NULL_HANDLE             ((psa_handle_t)0)
+#endif
+
+typedef struct psa_invec {
+    const void *base;
+    size_t len;
+} psa_invec;
+
+typedef struct psa_outvec {
+    void *base;
+    size_t len;
+} psa_outvec;
+
+#endif /* PSA_IPC_IMPLEMENTED */
+
+#endif /* _PAL_COMMON_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_config.h
@@ -1,0 +1,104 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_CONFIG_H_
+#define _PAL_CONFIG_H_
+
+/*
+ * List of macros used by test suite
+ */
+#if !defined(PSA_IPC_IMPLEMENTED)
+#define PSA_IPC_IMPLEMENTED 0
+#endif
+
+#if !defined(PSA_CRYPTO_IMPLEMENTED)
+#define PSA_CRYPTO_IMPLEMENTED 0
+#endif
+
+#if !defined(PSA_INTERNAL_TRUSTED_STORAGE_IMPLEMENTED)
+#define PSA_INTERNAL_TRUSTED_STORAGE_IMPLEMENTED 0
+#endif
+
+#if !defined(PSA_PROTECTED_STORAGE_IMPLEMENTED)
+#define PSA_PROTECTED_STORAGE_IMPLEMENTED 0
+#endif
+
+#if !defined(PSA_INITIAL_ATTESTATION_IMPLEMENTED)
+#define PSA_INITIAL_ATTESTATION_IMPLEMENTED 0
+#endif
+
+#if (PSA_IPC_IMPLEMENTED == 0) && \
+    (PSA_CRYPTO_IMPLEMENTED == 0) && \
+    (PSA_INTERNAL_TRUSTED_STORAGE_IMPLEMENTED == 0) && \
+    (PSA_PROTECTED_STORAGE_IMPLEMENTED == 0) && \
+    (PSA_INITIAL_ATTESTATION_IMPLEMENTED == 0)
+#error "You must define at least one of these macros to run test suite"
+#endif
+
+#if !defined(VERBOSE)
+#define VERBOSE 4 /* Print verbosity = ERROR */
+#endif
+
+#if (!defined(VAL_NSPE_BUILD) && !defined(SPE_BUILD))
+#define VAL_NSPE_BUILD 1
+#endif
+
+#if (!defined(NONSECURE_TEST_BUILD) && !defined(SPE_BUILD))
+#define NONSECURE_TEST_BUILD 1
+#endif
+
+#if !defined(TEST_COMBINE_ARCHIVE)
+//#define TEST_COMBINE_ARCHIVE /* Test dispatcher code selection */
+#endif
+
+/*
+ * Include of PSA defined Header files
+ */
+
+#if PSA_IPC_IMPLEMENTED
+/* psa/client.h: Contains the PSA Client API elements */
+#include "psa/client.h"
+
+/*
+ * psa_manifest/sid.h:  Macro definitions derived from manifest files that map from RoT Service
+ * names to Service IDs (SIDs). Partition manifest parse build tool must provide the implementation
+ * of this file.
+*/
+#include "psa_manifest/sid.h"
+#endif
+
+#if PSA_CRYPTO_IMPLEMENTED
+/* psa/crypto.h: Contains the PSA Crypto API elements */
+#include "psa/crypto.h"
+#endif
+
+#if PSA_INTERNAL_TRUSTED_STORAGE_IMPLEMENTED
+/* psa/internal_trusted_storage.h: Contains the PSA ITS API elements */
+#include "psa/internal_trusted_storage.h"
+#endif
+
+#if PSA_PROTECTED_STORAGE_IMPLEMENTED
+/* psa/protected_storage.h: Contains the PSA PS API elements */
+#include "psa/protected_storage.h"
+#endif
+
+#if PSA_INITIAL_ATTESTATION_IMPLEMENTED
+/* psa/initial_attestation.h: Contains the PSA Initial Attestation API elements */
+#include "psa/initial_attestation.h"
+#endif
+
+#endif /* _PAL_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_driver_ipc_intf.c
@@ -1,0 +1,305 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+#include "pal_client_api_intf.h"
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - SUCCESS/FAILURE
+**/
+int pal_uart_init_ns(uint32_t uart_base_addr)
+{
+    psa_handle_t            print_handle = 0;
+    psa_status_t            status_of_call = PSA_SUCCESS;
+    uart_fn_type_t          uart_fn = UART_INIT;
+
+    psa_invec data[3] = {{&uart_fn, sizeof(uart_fn)},
+                         {&uart_base_addr, sizeof(uart_base_addr)},
+                         {NULL, 0}};
+
+    print_handle = pal_ipc_connect(DRIVER_UART_SID, 0);
+    if (print_handle < 0)
+    {
+        return(PAL_STATUS_ERROR);
+    }
+
+    status_of_call = pal_ipc_call(print_handle, data, 3, NULL, 0);
+    if (status_of_call != PSA_SUCCESS)
+    {
+        return(PAL_STATUS_ERROR);
+    }
+
+    pal_ipc_close(print_handle);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+    @return   - SUCCESS/FAILURE
+**/
+
+int pal_print_ns(char *str, uint32_t data)
+{
+    int             string_len = 0;
+    char            *p = str;
+    psa_handle_t    print_handle = 0;
+    psa_status_t    status_of_call = PSA_SUCCESS;
+    pal_status_t    status = PAL_STATUS_SUCCESS;
+    uart_fn_type_t  uart_fn = UART_PRINT;
+
+    while (*p != '\0')
+    {
+        string_len++;
+        p++;
+    }
+
+    psa_invec data1[3] = {{&uart_fn, sizeof(uart_fn)},
+                          {str, string_len+1},
+                          {&data, sizeof(data)}};
+    print_handle = pal_ipc_connect(DRIVER_UART_SID, 0);
+
+    if (print_handle < 0)
+    {
+        return PAL_STATUS_ERROR;
+    }
+    else
+    {
+        status_of_call = pal_ipc_call(print_handle, data1, 3, NULL, 0);
+        if (status_of_call != PSA_SUCCESS)
+        {
+            status = PAL_STATUS_ERROR;
+        }
+    }
+    pal_ipc_close(print_handle);
+    return status;
+}
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
+{
+    wd_param_t              wd_param;
+    psa_handle_t            handle = 0;
+    psa_status_t            status_of_call = PSA_SUCCESS;
+
+    wd_param.wd_fn_type = WD_INIT_SEQ;
+    wd_param.wd_base_addr = base_addr;
+    wd_param.wd_time_us = time_us;
+    wd_param.wd_timer_tick_us = timer_tick_us;
+    psa_invec invec[1] = {{&wd_param, sizeof(wd_param)}};
+
+    handle = pal_ipc_connect(DRIVER_WATCHDOG_SID, 0);
+    if (handle < 0)
+    {
+        return PAL_STATUS_ERROR;
+    }
+    else
+    {
+        status_of_call = pal_ipc_call(handle, invec, 1, NULL, 0);
+        if (status_of_call != PSA_SUCCESS)
+        {
+            pal_ipc_close(handle);
+            return PAL_STATUS_ERROR;
+        }
+    }
+   pal_ipc_close(handle);
+   return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_enable_ns(addr_t base_addr)
+{
+    wd_param_t              wd_param;
+    psa_handle_t            handle = 0;
+    psa_status_t            status_of_call = PSA_SUCCESS;
+
+    wd_param.wd_fn_type = WD_ENABLE_SEQ;
+    wd_param.wd_base_addr = base_addr;
+    wd_param.wd_time_us = 0;
+    wd_param.wd_timer_tick_us = 0;
+    psa_invec invec[1] = {{&wd_param, sizeof(wd_param)}};
+
+    handle = pal_ipc_connect(DRIVER_WATCHDOG_SID, 0);
+    if (handle < 0)
+    {
+        return PAL_STATUS_ERROR;
+    }
+    else
+    {
+        status_of_call = pal_ipc_call(handle, invec, 1, NULL, 0);
+        if (status_of_call != PSA_SUCCESS)
+        {
+            pal_ipc_close(handle);
+            return PAL_STATUS_ERROR;
+        }
+    }
+   pal_ipc_close(handle);
+   return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - base_addr  : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_disable_ns(addr_t base_addr)
+{
+    wd_param_t              wd_param;
+    psa_handle_t            handle = 0;
+    psa_status_t            status_of_call = PSA_SUCCESS;
+
+    wd_param.wd_fn_type = WD_DISABLE_SEQ;
+    wd_param.wd_base_addr = base_addr;
+    wd_param.wd_time_us = 0;
+    wd_param.wd_timer_tick_us = 0;
+    psa_invec invec[1] = {{&wd_param, sizeof(wd_param)}};
+
+    handle = pal_ipc_connect(DRIVER_WATCHDOG_SID, 0);
+    if (handle < 0)
+    {
+        return PAL_STATUS_ERROR;
+    }
+    else
+    {
+        status_of_call = pal_ipc_call(handle, invec, 1, NULL, 0);
+        if (status_of_call != PSA_SUCCESS)
+        {
+            pal_ipc_close(handle);
+            return PAL_STATUS_ERROR;
+        }
+    }
+   pal_ipc_close(handle);
+   return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    nvmem_param_t   nvmem_param;
+    psa_handle_t    handle = 0;
+    psa_status_t    status_of_call = PSA_SUCCESS;
+
+    nvmem_param.nvmem_fn_type = NVMEM_READ;
+    nvmem_param.base = base;
+    nvmem_param.offset = offset;
+    nvmem_param.size = size;
+    psa_invec invec[1] = {{&nvmem_param, sizeof(nvmem_param)}};
+    psa_outvec outvec[1] = {{buffer, size}};
+
+    handle = pal_ipc_connect(DRIVER_NVMEM_SID, 0);
+    if (handle < 0)
+    {
+        return PAL_STATUS_ERROR;
+    }
+    else
+    {
+        status_of_call = pal_ipc_call(handle, invec, 1, outvec, 1);
+        if (status_of_call != PSA_SUCCESS)
+        {
+            pal_ipc_close(handle);
+            return PAL_STATUS_ERROR;
+        }
+    }
+   psa_close(handle);
+   return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_write_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    nvmem_param_t   nvmem_param;
+    psa_handle_t    handle = 0;
+    psa_status_t    status_of_call = PSA_SUCCESS;
+
+    nvmem_param.nvmem_fn_type = NVMEM_WRITE;
+    nvmem_param.base = base;
+    nvmem_param.offset = offset;
+    nvmem_param.size = size;
+    psa_invec invec[2] = {{&nvmem_param, sizeof(nvmem_param)}, {buffer, size}};
+
+    handle = pal_ipc_connect(DRIVER_NVMEM_SID, 0);
+    if (handle < 0)
+    {
+        return PAL_STATUS_ERROR;
+    }
+    else
+    {
+        status_of_call = pal_ipc_call(handle, invec, 2, NULL, 0);
+        if (status_of_call != PSA_SUCCESS)
+        {
+            pal_ipc_close(handle);
+            return PAL_STATUS_ERROR;
+        }
+    }
+   pal_ipc_close(handle);
+   return PAL_STATUS_SUCCESS;
+}
+
+/**
+ *   @brief    - This function will read peripherals using SPI commands
+ *   @param    - addr : address of the peripheral
+ *               data : read buffer
+ *               len  : length of the read buffer in bytes
+ *   @return   - error status
+**/
+int pal_spi_read(addr_t addr, uint8_t *data, uint32_t len)
+{
+    return 0xFF;
+}
+
+/**
+ *   @brief    - Terminates the simulation at the end of all tests completion.
+ *               By default, it put cpus into power down mode.
+ *   @param    - void
+ *   @return   - void
+**/
+void pal_terminate_simulation(void)
+{
+    /* Add logic to terminate the simluation */
+
+    while(1)
+    {
+        asm volatile("WFI");
+    }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_driver_ns_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/common/pal_driver_ns_intf.c
@@ -1,0 +1,145 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+#include "pal_uart.h"
+#include "pal_nvmem.h"
+#include "pal_wd_cmsdk.h"
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - SUCCESS/FAILURE
+**/
+int pal_uart_init_ns(uint32_t uart_base_addr)
+{
+    pal_uart_pl011_init(uart_base_addr);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+    @return   - SUCCESS/FAILURE
+**/
+
+int pal_print_ns(char *str, uint32_t data)
+{
+    pal_uart_pl011_print(str, data);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
+{
+    return(pal_wd_cmsdk_init(base_addr,time_us, timer_tick_us));
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_enable_ns(addr_t base_addr)
+{
+    return(pal_wd_cmsdk_enable(base_addr));
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - base_addr  : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_disable_ns(addr_t base_addr)
+{
+    return (pal_wd_cmsdk_disable(base_addr));
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    if (nvmem_read(base, offset, buffer, size))
+    {
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+}
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvmem_write_ns(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    if (nvmem_write(base, offset, buffer, size))
+    {
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+}
+
+/**
+ *   @brief    - This function will read peripherals using SPI commands
+ *   @param    - addr : address of the peripheral
+ *               data : read buffer
+ *               len  : length of the read buffer in bytes
+ *   @return   - error status
+**/
+int pal_spi_read(addr_t addr, uint8_t *data, uint32_t len)
+{
+    return 0xFF;
+}
+
+/**
+ *   @brief    - Terminates the simulation at the end of all tests completion.
+ *               By default, it put cpus into power down mode.
+ *   @param    - void
+ *   @return   - void
+**/
+void pal_terminate_simulation(void)
+{
+    /* Add logic to terminate the simluation */
+
+    while(1)
+    {
+        asm volatile("WFI");
+    }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_config.h
@@ -1,0 +1,323 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+/*
+ * \file pal_crypto_config.h
+ *
+ * \brief Configuration options for crypto tests (set of defines)
+ *
+ *  This set of compile-time options may be used to enable
+ *  or disable features selectively for crypto test suite
+ */
+
+#ifndef _PAL_CRYPTO_CONFIG_H_
+#define _PAL_CRYPTO_CONFIG_H_
+/**
+ * \def ARCH_TEST_RSA
+ *
+ * Enable the RSA public-key cryptosystem.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_RSA
+#define ARCH_TEST_RSA_1024
+#define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_3072
+
+/**
+ * \def  ARCH_TEST_ECC
+ * \def  ARCH_TEST_ECC_CURVE_SECPXXXR1
+ *
+ * Enable the elliptic curve
+ * Enable specific curves within the Elliptic Curve
+ * module.  By default all supported curves are enabled.
+ *
+ * Requires: ARCH_TEST_ECC
+ * Comment macros to disable the curve
+ */
+#define ARCH_TEST_ECC
+#define ARCH_TEST_ECC_CURVE_SECP192R1
+#define ARCH_TEST_ECC_CURVE_SECP224R1
+#define ARCH_TEST_ECC_CURVE_SECP256R1
+#define ARCH_TEST_ECC_CURVE_SECP384R1
+
+/**
+ * \def ARCH_TEST_AES
+ *
+ * Enable the AES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_AES
+#define ARCH_TEST_AES_128
+#define ARCH_TEST_AES_192
+#define ARCH_TEST_AES_256
+#define ARCH_TEST_AES_512
+
+/**
+ * \def  ARCH_TEST_DES
+ *
+ * Enable the DES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_DES
+#define ARCH_TEST_DES_1KEY
+#define ARCH_TEST_DES_2KEY
+#define ARCH_TEST_DES_3KEY
+
+/**
+ * \def  ARCH_TEST_RAW
+ *
+ * A "key" of this type cannot be used for any cryptographic operation.
+ * Applications may use this type to store arbitrary data in the keystore.
+ */
+#define ARCH_TEST_RAW
+
+/**
+ * \def ARCH_TEST_CIPER
+ *
+ * Enable the generic cipher layer.
+ */
+
+#define ARCH_TEST_CIPER
+
+/**
+ * \def ARCH_TEST_ARC4
+ *
+ * Enable the ARC4 key type.
+ */
+#define ARCH_TEST_ARC4
+
+/**
+ * \def ARCH_TEST_CIPER_MODE_CTR
+ *
+ * Enable Counter Block Cipher mode (CTR) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPER
+ */
+#define ARCH_TEST_CIPER_MODE_CTR
+
+/**
+ * \def ARCH_TEST_CIPER_MODE_CFB
+ *
+ * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPER
+ */
+#define ARCH_TEST_CIPER_MODE_CFB
+
+/**
+ * \def ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPER
+ */
+#define ARCH_TEST_CIPER_MODE_CBC
+
+/**
+ * \def ARCH_TEST_CTR_AES
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_AES, ARCH_TEST_CIPER_MODE_CTR
+ */
+#define ARCH_TEST_CTR_AES
+
+/**
+ * \def ARCH_TEST_CBC_AES
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_AES, ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_AES
+#define ARCH_TEST_CBC_AES_NO_PADDING
+
+/**
+ * \def ARCH_TEST_CBC_NO_PADDING
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_NO_PADDING
+
+/**
+ * \def ARCH_TEST_CFB_AES
+ *
+ * Requires: ARCH_TEST_CIPER, ARCH_TEST_AES, ARCH_TEST_CIPER_MODE_CFB
+ */
+#define ARCH_TEST_CFB_AES
+
+/**
+ * \def ARCH_TEST_PKCS1V15_*
+ *
+ * Enable support for PKCS#1 v1.5 encoding.
+ * Enable support for PKCS#1 v1.5 operations.
+ * Enable support for RSA-OAEP
+ *
+ * Requires: ARCH_TEST_RSA, ARCH_TEST_PKCS1V15
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_PKCS1V15
+#define ARCH_TEST_RSA_PKCS1V15_SIGN
+#define ARCH_TEST_RSA_PKCS1V15_SIGN_RAW
+#define ARCH_TEST_RSA_PKCS1V15_CRYPT
+#define ARCH_TEST_RSA_OAEP
+
+/**
+ * \def ARCH_TEST_CBC_PKCS7
+ *
+ * Requires: ARCH_TEST_CIPER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_PKCS7
+
+/**
+ * \def ARCH_TEST_ASYMMETRIC_ENCRYPTION
+ *
+ * Enable support for Asymmetric encryption algorithms
+ */
+#define ARCH_TEST_ASYMMETRIC_ENCRYPTION
+
+/**
+ * \def ARCH_TEST_HASH
+ *
+ * Enable the hash algorithm.
+ */
+#define ARCH_TEST_HASH
+
+/**
+ * \def  ARCH_TEST_HMAC
+ *
+ * The key policy determines which underlying hash algorithm the key can be
+ * used for.
+ *
+ * Requires: ARCH_TEST_HASH
+ */
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_MDX
+ * \def ARCH_TEST_SHAXXX
+ *
+ * Enable the MDX algorithm.
+ * Enable the SHAXXX algorithm.
+ *
+ * Requires: ARCH_TEST_HASH
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_MD2
+#define ARCH_TEST_MD4
+#define ARCH_TEST_MD5
+#define ARCH_TEST_RIPEMD160
+#define ARCH_TEST_SHA1
+#define ARCH_TEST_SHA224
+#define ARCH_TEST_SHA256
+#define ARCH_TEST_SHA384
+#define ARCH_TEST_SHA512
+#define ARCH_TEST_SHA512_224
+#define ARCH_TEST_SHA512_256
+#define ARCH_TEST_SHA3_224
+#define ARCH_TEST_SHA3_256
+#define ARCH_TEST_SHA3_384
+#define ARCH_TEST_SHA3_512
+
+/**
+ * \def ARCH_TEST_HKDF
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Requires: ARCH_TEST_HASH
+*/
+#define ARCH_TEST_HKDF
+
+/**
+ * \def ARCH_TEST_xMAC
+ *
+ * Enable the xMAC (Cipher/Hash/G-based Message Authentication Code) mode for block
+ * ciphers.
+ * Requires: ARCH_TEST_AES or ARCH_TEST_DES
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CMAC
+#define ARCH_TEST_GMAC
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_CCM
+ *
+ * Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher.
+ *
+ * Requires: ARCH_TEST_AES
+ */
+#define ARCH_TEST_CCM
+
+/**
+ * \def ARCH_TEST_GCM
+ *
+ * Enable the Galois/Counter Mode (GCM) for AES.
+ *
+ * Requires: ARCH_TEST_AES
+ *
+ */
+#define ARCH_TEST_GCM
+
+/**
+ * \def ARCH_TEST_TRUNCATED_MAC
+ *
+ * Enable support for RFC 6066 truncated HMAC in SSL.
+ *
+ * Comment this macro to disable support for truncated HMAC in SSL
+ */
+#define ARCH_TEST_TRUNCATED_MAC
+
+
+/**
+ * \def ARCH_TEST_ECDH
+ *
+ * Enable the elliptic curve Diffie-Hellman library.
+ *
+ * Requires: ARCH_TEST_ECC
+ */
+#define ARCH_TEST_ECDH
+
+/**
+ * \def ARCH_TEST_ECDSA
+ *
+ * Enable the elliptic curve DSA library.
+ * Requires: ARCH_TEST_ECC
+ */
+#define ARCH_TEST_ECDSA
+
+/**
+ * \def ARCH_TEST_DETERMINISTIC_ECDSA
+ *
+ * Enable deterministic ECDSA (RFC 6979).
+*/
+#define ARCH_TEST_DETERMINISTIC_ECDSA
+
+#include "pal_crypto_config_check.h"
+
+#endif /* _PAL_CRYPTO_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_config_check.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_config_check.h
@@ -1,0 +1,223 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+/**
+ * \file pal_crypto_config_check.h
+ *
+ * \brief Consistency checks for configuration options
+ *
+ */
+
+#ifndef _PAL_CRYPTO_CONFIG_CHECK_H_
+#define _PAL_CRYPTO_CONFIG_CHECK_H_
+
+#if defined(ARCH_TEST_RSA_1024) && !defined(ARCH_TEST_RSA)
+#error "ARCH_TEST_RSA_1024 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_RSA_2048) && !defined(ARCH_TEST_RSA)
+#error "ARCH_TEST_RSA_2048 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_RSA_3072) && !defined(ARCH_TEST_RSA)
+#error "ARCH_TEST_RSA_3072 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_ECC_CURVE_SECP192R1) && !defined(ARCH_TEST_ECC)
+#error "ARCH_TEST_ECC_CURVE_SECP192R1 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_ECC_CURVE_SECP224R1) && !defined(ARCH_TEST_ECC)
+#error "ARCH_TEST_ECC_CURVE_SECP224R1 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_ECC_CURVE_SECP256R1) && !defined(ARCH_TEST_ECC)
+#error "ARCH_TEST_ECC_CURVE_SECP256R1 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_ECC_CURVE_SECP384R1) && !defined(ARCH_TEST_ECC)
+#error "ARCH_TEST_ECC_CURVE_SECP384R1 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_AES_128) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_AES_128 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_AES_256) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_AES_256 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_AES_512) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_AES_512 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_DES_1KEY) && !defined(ARCH_TEST_DES)
+#error "ARCH_TEST_DES_1KEY defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_DES_2KEY) && !defined(ARCH_TEST_DES)
+#error "ARCH_TEST_DES_2KEY defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_DES_3KEY) && !defined(ARCH_TEST_DES)
+#error "ARCH_TEST_DES_3KEY defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CIPER_MODE_CTR) && !defined(ARCH_TEST_CIPER)
+#error "ARCH_TEST_CIPER_MODE_CTR defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CIPER_MODE_CFB) && !defined(ARCH_TEST_CIPER)
+#error "ARCH_TEST_CIPER_MODE_CFB defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CIPER_MODE_CBC) && !defined(ARCH_TEST_CIPER)
+#error "ARCH_TEST_CIPER_MODE_CBC defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CTR_AES) &&\
+    (!defined(ARCH_TEST_CIPER) || !defined(ARCH_TEST_AES) || !defined(ARCH_TEST_CIPER_MODE_CTR))
+#error "ARCH_TEST_CTR_AES defined, but not all prerequisites"
+#endif
+
+#if (defined(ARCH_TEST_CBC_AES)|| defined(ARCH_TEST_CBC_AES_NO_PADDING)) &&\
+    (!defined(ARCH_TEST_CIPER) || !defined(ARCH_TEST_AES) || !defined(ARCH_TEST_CIPER_MODE_CBC))
+#error "ARCH_TEST_CBC_AES defined, but not all prerequisites"
+#endif
+
+#if (defined(ARCH_TEST_CBC_NO_PADDING)) &&\
+    (!defined(ARCH_TEST_CIPER) ||!defined(ARCH_TEST_CIPER_MODE_CBC))
+#error "ARCH_TEST_CBC_NO_PADDING defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CFB_AES) &&\
+    (!defined(ARCH_TEST_CIPER) || !defined(ARCH_TEST_AES) || !defined(ARCH_TEST_CIPER_MODE_CFB))
+#error "ARCH_TEST_CFB_AES defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_RSA_PKCS1V15_SIGN) &&\
+    (!defined(ARCH_TEST_RSA) || !defined(ARCH_TEST_PKCS1V15))
+#error "ARCH_TEST_RSA_PKCS1V15_SIGN defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_RSA_PKCS1V15_SIGN_RAW) &&\
+    (!defined(ARCH_TEST_RSA) || !defined(ARCH_TEST_PKCS1V15))
+#error "ARCH_TEST_RSA_PKCS1V15_SIGN_RAW defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_RSA_PKCS1V15_CRYPT) &&\
+    (!defined(ARCH_TEST_RSA) || !defined(ARCH_TEST_PKCS1V15))
+#error "ARCH_TEST_RSA_PKCS1V15_CRYPT defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CBC_PKCS7) && !defined(ARCH_TEST_CIPER_MODE_CBC)
+#error "ARCH_TEST_CBC_PKCS7 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_HMAC) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_HMAC defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_MD2) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_MD2 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_MD4) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_MD4 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_MD5) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_MD5 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_RIPEMD160) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_RIPEMD160 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA1) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA1 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA224) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA224 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA256) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA256 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA512) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA512 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA512_224) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA512_224 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA512_256) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA512_256 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA3_224) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA3_224 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA3_256) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA3_256 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA3_384) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA3_256 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_SHA3_512) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_SHA3_256 defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_HKDF) && !defined(ARCH_TEST_HASH)
+#error "ARCH_TEST_HKDF defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CMAC) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_CMAC defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_GMAC) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_GMAC defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_HMAC) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_HMAC defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_CCM) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_CCM defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_GCM) && !defined(ARCH_TEST_AES)
+#error "ARCH_TEST_GCM defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_ECDH) && !defined(ARCH_TEST_ECC)
+#error "ARCH_TEST_ECDH defined, but not all prerequisites"
+#endif
+
+#if defined(ARCH_TEST_ECDSA) && !defined(ARCH_TEST_ECC)
+#error "ARCH_TEST_ECDSA defined, but not all prerequisites"
+#endif
+
+#endif /* _PAL_CRYPTO_CONFIG_CHECK_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_empty_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_empty_intf.c
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include <stdarg.h>
+#include "pal_common.h"
+
+/**
+    @brief    - This API will call the requested crypto function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+int32_t pal_crypto_function(int type, va_list valist)
+{
+    return PAL_STATUS_ERROR;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.c
@@ -1,0 +1,335 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+
+#include "pal_crypto_intf.h"
+
+#define  PAL_KEY_SLOT_COUNT  32
+
+/**
+    @brief    - This API will call the requested crypto function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+int32_t pal_crypto_function(int type, va_list valist)
+{
+    int                     i;
+    size_t                  size, *length, salt_length, label_length, ciphertext_size;
+    uint8_t                 *buffer, *ciphertext;
+    const uint8_t           *salt, *label, *nonce, *additional_data;
+    uint8_t                 *plaintext;
+    uint32_t                status;
+    const void              *extra;
+    size_t                  extra_size, capacity, *gen_cap, nonce_length, additional_data_length;
+    psa_key_handle_t        handle, *key_handle;
+    psa_key_type_t          key_type, *key_type_out;
+    psa_key_policy_t        *policy;
+    psa_key_usage_t         usage, *usage_out;
+    psa_key_lifetime_t      *lifetime_out;
+    psa_algorithm_t         alg, *alg_out;
+    psa_hash_operation_t    *hash_operation;
+    psa_mac_operation_t     *mac_operation;
+    psa_cipher_operation_t  *cipher_operation;
+    psa_crypto_generator_t  *generator;
+
+    switch (type)
+    {
+        case PAL_CRYPTO_INIT:
+            return psa_crypto_init();
+        case PAL_CRYPTO_GENERATE_RANDOM:
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, int);
+            return psa_generate_random(buffer, size);
+        case PAL_CRYPTO_IMPORT_KEY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            key_type = va_arg(valist, psa_key_type_t);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, int);
+            status = psa_import_key(handle, key_type, buffer, size);
+            return status;
+        case PAL_CRYPTO_EXPORT_KEY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            buffer = (uint8_t *)(va_arg(valist, uint8_t*));
+            size = va_arg(valist, int);
+            length = (size_t *)va_arg(valist, size_t*);
+            status = psa_export_key(handle, buffer, size, length);
+            return status;
+        case PAL_CRYPTO_EXPORT_PUBLIC_KEY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            buffer = (uint8_t *)(va_arg(valist, uint8_t*));
+            size = va_arg(valist, int);
+            length = (size_t *)va_arg(valist, size_t*);
+            status = psa_export_public_key(handle, buffer, size, length);
+            return status;
+        case PAL_CRYPTO_KEY_POLICY_INIT:
+            policy = va_arg(valist, psa_key_policy_t*);
+            memset(policy, 0, sizeof(psa_key_policy_t));
+            return 0;
+        case PAL_CRYPTO_KEY_POLICY_SET_USAGE:
+            policy = va_arg(valist, psa_key_policy_t*);
+            usage = va_arg(valist, psa_key_usage_t);
+            alg = va_arg(valist, psa_algorithm_t);
+            psa_key_policy_set_usage(policy, usage, alg);
+            return 0;
+        case PAL_CRYPTO_SET_KEY_POLICY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            policy = va_arg(valist, psa_key_policy_t*);
+            return psa_set_key_policy(handle, policy);
+        case PAL_CRYPTO_DESTROY_KEY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            status = psa_destroy_key(handle);
+            return status;
+        case PAL_CRYPTO_GET_KEY_INFORMATION:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            key_type_out = va_arg(valist, psa_key_type_t*);
+            length = (size_t *)va_arg(valist, size_t*);
+            status = psa_get_key_information(handle, key_type_out, length);
+            return status;
+        case PAL_CRYPTO_GET_KEY_POLICY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            policy = va_arg(valist, psa_key_policy_t*);
+            return psa_get_key_policy(handle, policy);
+        case PAL_CRYPTO_KEY_POLICY_GET_USAGE:
+            policy = va_arg(valist, psa_key_policy_t*);
+            usage_out = va_arg(valist, psa_key_usage_t*);
+            *usage_out = psa_key_policy_get_usage(policy);
+            return 0;
+        case PAL_CRYPTO_KEY_POLICY_GET_ALGORITHM:
+            policy = va_arg(valist, psa_key_policy_t*);
+            alg_out = va_arg(valist, psa_algorithm_t*);
+            *alg_out = psa_key_policy_get_algorithm(policy);
+            return 0;
+        case PAL_CRYPTO_GET_KEY_LIFETIME:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            lifetime_out = va_arg(valist, psa_key_lifetime_t*);
+            return psa_get_key_lifetime(handle, lifetime_out);
+        case PAL_CRYPTO_HASH_SETUP:
+            hash_operation = va_arg(valist, psa_hash_operation_t*);
+            alg = va_arg(valist, psa_algorithm_t);
+            return psa_hash_setup(hash_operation, alg);
+        case PAL_CRYPTO_HASH_UPDATE:
+            hash_operation = va_arg(valist, psa_hash_operation_t*);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            return psa_hash_update(hash_operation, buffer, size);
+        case PAL_CRYPTO_HASH_VERIFY:
+            hash_operation = va_arg(valist, psa_hash_operation_t*);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            return psa_hash_verify(hash_operation, buffer, size);
+        case PAL_CRYPTO_HASH_FINISH:
+            hash_operation = va_arg(valist, psa_hash_operation_t*);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_hash_finish(hash_operation, buffer, size, length);
+        case PAL_CRYPTO_HASH_ABORT:
+            hash_operation = va_arg(valist, psa_hash_operation_t*);
+            return psa_hash_abort(hash_operation);
+        case PAL_CRYPTO_GENERATE_KEY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            key_type = va_arg(valist, psa_key_type_t);
+            size     = va_arg(valist, size_t);
+            extra    = va_arg(valist, const void*);
+            extra_size  = va_arg(valist, size_t);
+            return psa_generate_key(handle, key_type, size, extra, extra_size);
+        case PAL_CRYPTO_GENERATOR_READ:
+            generator = va_arg(valist, psa_crypto_generator_t*);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, int);
+            return psa_generator_read(generator, buffer, size);
+        case PAL_CRYPTO_KEY_DERIVATION:
+            generator = va_arg(valist, psa_crypto_generator_t*);
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            salt = va_arg(valist, const uint8_t *);
+            salt_length = va_arg(valist, size_t);
+            label = va_arg(valist, const uint8_t *);
+            label_length = va_arg(valist, size_t);
+            capacity = va_arg(valist, size_t);
+            return psa_key_derivation(generator, handle, alg, salt, salt_length, label,
+                                                                  label_length, capacity);
+        case PAL_CRYPTO_GET_GENERATOR_CAPACITY:
+            generator = va_arg(valist, psa_crypto_generator_t*);
+            gen_cap   = va_arg(valist, size_t*);
+            return psa_get_generator_capacity(generator, gen_cap);
+        case PAL_CRYPTO_GENERATOR_IMPORT_KEY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            key_type = va_arg(valist, psa_key_type_t);
+            size     = va_arg(valist, size_t);
+            generator = va_arg(valist, psa_crypto_generator_t*);
+            return psa_generator_import_key(handle, key_type, size, generator);
+        case PAL_CRYPTO_GENERATOR_ABORT:
+            generator = va_arg(valist, psa_crypto_generator_t*);
+            return psa_generator_abort(generator);
+        case PAL_CRYPTO_AEAD_ENCRYPT:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            nonce = va_arg(valist, const uint8_t *);
+            nonce_length = va_arg(valist, size_t);
+            additional_data = va_arg(valist, const uint8_t *);
+            additional_data_length = va_arg(valist, size_t);
+            plaintext = va_arg(valist, uint8_t *);
+            size = va_arg(valist, size_t);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_aead_encrypt(handle, alg, nonce, nonce_length, additional_data,
+                    additional_data_length, plaintext, size, ciphertext, ciphertext_size, length);
+        case PAL_CRYPTO_AEAD_DECRYPT:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            nonce = va_arg(valist, const uint8_t *);
+            nonce_length = va_arg(valist, size_t);
+            additional_data = va_arg(valist, const uint8_t *);
+            additional_data_length = va_arg(valist, size_t);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            plaintext = va_arg(valist, uint8_t *);
+            size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_aead_decrypt(handle, alg, nonce, nonce_length, additional_data,
+                    additional_data_length, ciphertext, ciphertext_size, plaintext, size, length);
+        case PAL_CRYPTO_MAC_SIGN_SETUP:
+            mac_operation = va_arg(valist, psa_mac_operation_t*);
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            return psa_mac_sign_setup(mac_operation, handle, alg);
+        case PAL_CRYPTO_MAC_UPDATE:
+            mac_operation = va_arg(valist, psa_mac_operation_t*);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            return psa_mac_update(mac_operation, buffer, size);
+        case PAL_CRYPTO_MAC_SIGN_FINISH:
+            mac_operation = va_arg(valist, psa_mac_operation_t*);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            length = (size_t *)va_arg(valist, size_t*);
+            return psa_mac_sign_finish(mac_operation, buffer, size, length);
+        case PAL_CRYPTO_MAC_VERIFY_SETUP:
+            mac_operation = va_arg(valist, psa_mac_operation_t*);
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            return psa_mac_verify_setup(mac_operation, handle, alg);
+        case PAL_CRYPTO_MAC_VERIFY_FINISH:
+            mac_operation = va_arg(valist, psa_mac_operation_t*);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            return psa_mac_verify_finish(mac_operation, buffer, size);
+        case PAL_CRYPTO_MAC_ABORT:
+            mac_operation = va_arg(valist, psa_mac_operation_t*);
+            return psa_mac_abort(mac_operation);
+        case PAL_CRYPTO_ASYMMTERIC_ENCRYPT:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            plaintext = va_arg(valist, uint8_t *);
+            size = va_arg(valist, size_t);
+            salt = va_arg(valist, const uint8_t *);
+            salt_length = va_arg(valist, size_t);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_asymmetric_encrypt(handle, alg, plaintext, size, salt, salt_length,
+                    ciphertext, ciphertext_size, length);
+        case PAL_CRYPTO_ASYMMTERIC_DECRYPT:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            plaintext = va_arg(valist, uint8_t *);
+            size = va_arg(valist, size_t);
+            salt = va_arg(valist, const uint8_t *);
+            salt_length = va_arg(valist, size_t);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_asymmetric_decrypt(handle, alg, plaintext, size, salt, salt_length,
+                    ciphertext, ciphertext_size, length);
+        case PAL_CRYPTO_CIPHER_ENCRYPT_SETUP:
+            cipher_operation =  va_arg(valist, psa_cipher_operation_t *);
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            return psa_cipher_encrypt_setup(cipher_operation, handle, alg);
+        case PAL_CRYPTO_CIPHER_DECRYPT_SETUP:
+            cipher_operation =  va_arg(valist, psa_cipher_operation_t *);
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            return psa_cipher_decrypt_setup(cipher_operation, handle, alg);
+        case PAL_CRYPTO_CIPHER_GENERATE_IV:
+            cipher_operation =  va_arg(valist, psa_cipher_operation_t *);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_cipher_generate_iv(cipher_operation, buffer, size, length);
+        case PAL_CRYPTO_CIPHER_SET_IV:
+            cipher_operation =  va_arg(valist, psa_cipher_operation_t *);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            return psa_cipher_set_iv(cipher_operation, buffer, size);
+        case PAL_CRYPTO_CIPHER_UPDATE:
+            cipher_operation =  va_arg(valist, psa_cipher_operation_t *);
+            plaintext = va_arg(valist, uint8_t *);
+            size = va_arg(valist, size_t);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_cipher_update(cipher_operation, plaintext, size, ciphertext, ciphertext_size,
+                                     length);
+        case PAL_CRYPTO_CIPHER_FINISH:
+            cipher_operation =  va_arg(valist, psa_cipher_operation_t *);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_cipher_finish(cipher_operation, ciphertext, ciphertext_size, length);
+        case PAL_CRYPTO_CIPHER_ABORT:
+            cipher_operation =  va_arg(valist, psa_cipher_operation_t *);
+            return psa_cipher_abort(cipher_operation);
+        case PAL_CRYPTO_ASYMMTERIC_SIGN:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            length = va_arg(valist, size_t*);
+            return psa_asymmetric_sign(handle, alg, buffer, size, ciphertext, ciphertext_size,
+                                       length);
+        case PAL_CRYPTO_ASYMMTERIC_VERIFY:
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            alg = va_arg(valist, psa_algorithm_t);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            ciphertext = va_arg(valist, uint8_t *);
+            ciphertext_size = va_arg(valist, size_t);
+            return psa_asymmetric_verify(handle, alg, buffer, size, ciphertext, ciphertext_size);
+        case PAL_CRYPTO_KEY_AGREEMENT:
+            generator = va_arg(valist, psa_crypto_generator_t*);
+            handle = (psa_key_handle_t)va_arg(valist, int);
+            buffer = va_arg(valist, uint8_t*);
+            size = va_arg(valist, size_t);
+            alg = va_arg(valist, psa_algorithm_t);
+            return psa_key_agreement(generator, handle, buffer, size, alg);
+        case PAL_CRYPTO_ALLOCATE_KEY:
+            key_handle = (psa_key_handle_t *)va_arg(valist, int*);
+            return psa_allocate_key(key_handle);
+        case PAL_CRYPTO_FREE:
+            for (i = 0; i < PAL_KEY_SLOT_COUNT; i++)
+                psa_destroy_key(i);
+            return 0;
+        default:
+            return PAL_STATUS_UNSUPPORTED_FUNC;
+    }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.h
@@ -1,0 +1,75 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_CRYPTO_H_
+#define _PAL_CRYPTO_H_
+
+#include "pal_common.h"
+
+enum crypto_function_code {
+    PAL_CRYPTO_INIT                     = 0x1,
+    PAL_CRYPTO_GENERATE_RANDOM          = 0x2,
+    PAL_CRYPTO_IMPORT_KEY               = 0x3,
+    PAL_CRYPTO_EXPORT_KEY               = 0x4,
+    PAL_CRYPTO_EXPORT_PUBLIC_KEY        = 0x5,
+    PAL_CRYPTO_DESTROY_KEY              = 0x6,
+    PAL_CRYPTO_GET_KEY_INFO             = 0x7,
+    PAL_CRYPTO_KEY_POLICY_INIT          = 0x8,
+    PAL_CRYPTO_KEY_POLICY_SET_USAGE     = 0x9,
+    PAL_CRYPTO_KEY_POLICY_GET_USAGE     = 0xA,
+    PAL_CRYPTO_KEY_POLICY_GET_ALGORITHM = 0xB,
+    PAL_CRYPTO_SET_KEY_POLICY           = 0xC,
+    PAL_CRYPTO_GET_KEY_POLICY           = 0xD,
+    PAL_CRYPTO_GET_KEY_INFORMATION      = 0xE,
+    PAL_CRYPTO_GET_KEY_LIFETIME         = 0xF,
+    PAL_CRYPTO_HASH_SETUP               = 0x11,
+    PAL_CRYPTO_HASH_UPDATE              = 0x12,
+    PAL_CRYPTO_HASH_VERIFY              = 0x13,
+    PAL_CRYPTO_HASH_FINISH              = 0x14,
+    PAL_CRYPTO_HASH_ABORT               = 0x15,
+    PAL_CRYPTO_GENERATE_KEY             = 0x16,
+    PAL_CRYPTO_GENERATOR_READ           = 0x17,
+    PAL_CRYPTO_KEY_DERIVATION           = 0x18,
+    PAL_CRYPTO_GET_GENERATOR_CAPACITY   = 0x19,
+    PAL_CRYPTO_GENERATOR_IMPORT_KEY     = 0x1A,
+    PAL_CRYPTO_GENERATOR_ABORT          = 0x1B,
+    PAL_CRYPTO_AEAD_ENCRYPT             = 0x1C,
+    PAL_CRYPTO_AEAD_DECRYPT             = 0x1D,
+    PAL_CRYPTO_MAC_SIGN_SETUP           = 0x1E,
+    PAL_CRYPTO_MAC_UPDATE               = 0x1F,
+    PAL_CRYPTO_MAC_SIGN_FINISH          = 0x20,
+    PAL_CRYPTO_MAC_VERIFY_SETUP         = 0x21,
+    PAL_CRYPTO_MAC_VERIFY_FINISH        = 0x22,
+    PAL_CRYPTO_MAC_ABORT                = 0x23,
+    PAL_CRYPTO_ASYMMTERIC_ENCRYPT       = 0x24,
+    PAL_CRYPTO_ASYMMTERIC_DECRYPT       = 0x25,
+    PAL_CRYPTO_CIPHER_ENCRYPT_SETUP     = 0x26,
+    PAL_CRYPTO_CIPHER_DECRYPT_SETUP     = 0x2A,
+    PAL_CRYPTO_CIPHER_GENERATE_IV       = 0x2B,
+    PAL_CRYPTO_CIPHER_SET_IV            = 0x2C,
+    PAL_CRYPTO_CIPHER_UPDATE            = 0x2D,
+    PAL_CRYPTO_CIPHER_FINISH            = 0x2E,
+    PAL_CRYPTO_CIPHER_ABORT             = 0x2F,
+    PAL_CRYPTO_ASYMMTERIC_SIGN          = 0x30,
+    PAL_CRYPTO_ASYMMTERIC_VERIFY        = 0x31,
+    PAL_CRYPTO_KEY_AGREEMENT            = 0x32,
+    PAL_CRYPTO_ALLOCATE_KEY             = 0x33,
+    PAL_CRYPTO_FREE                     = 0xFE,
+};
+
+int32_t pal_crypto_function(int type, va_list valist);
+#endif /* _PAL_CRYPTO_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_eat.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_eat.c
@@ -1,0 +1,385 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_attestation_eat.h"
+
+uint32_t  mandatory_claims = 0, mandaroty_sw_components = 0;
+bool_t    sw_component_present = 0;
+
+static int get_items_in_map(QCBORDecodeContext *decode_context,
+                            struct items_to_get_t *item_list)
+{
+    int                     item_index;
+    QCBORItem               item;
+    struct items_to_get_t  *item_ptr = item_list;
+
+    /* initialize the data type of all items in the list */
+    while (item_ptr->label != 0)
+    {
+        item_ptr->item.uDataType = QCBOR_TYPE_NONE;
+        item_ptr++;
+    }
+
+    QCBORDecode_GetNext(decode_context, &item);
+    if (item.uDataType != QCBOR_TYPE_MAP)
+    {
+        return PAL_ATTEST_ERROR;
+    }
+
+    for (item_index = item.val.uCount; item_index != 0; item_index--)
+    {
+        if (QCBORDecode_GetNext(decode_context, &item) != QCBOR_SUCCESS)
+        {
+            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+        }
+        if (item.uLabelType != QCBOR_TYPE_INT64)
+        {
+            continue;
+        }
+
+        item_ptr = item_list;
+        while (item_ptr->label != 0)
+        {
+            if (item.label.int64 == item_ptr->label)
+            {
+                item_ptr->item = item;
+            }
+            item_ptr++;
+        }
+    }
+
+    return PAL_ATTEST_SUCCESS;
+}
+
+static int get_item_in_map(QCBORDecodeContext *decode_context,
+                           int32_t label,
+                           QCBORItem *item)
+{
+    struct items_to_get_t   item_list[2];
+
+    item_list[0].label = label;
+    item_list[1].label = 0;
+
+    if (get_items_in_map(decode_context, item_list))
+    {
+        return PAL_ATTEST_ERROR;
+    }
+
+    if (item_list[0].item.uDataType == QCBOR_TYPE_NONE)
+    {
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+    }
+
+    *item = item_list[0].item;
+
+    return PAL_ATTEST_SUCCESS;
+}
+
+static int parse_unprotected_headers(QCBORDecodeContext *decode_context,
+                                     struct useful_buf_c *child,
+                                     bool *loop_back)
+{
+    struct items_to_get_t   item_list[3];
+
+    item_list[0].label = COSE_HEADER_PARAM_KID;
+    item_list[1].label = T_COSE_SHORT_CIRCUIT_LABEL;
+    item_list[2].label = 0;
+    *loop_back = false;
+
+    if (get_items_in_map(decode_context, item_list))
+    {
+        return PAL_ATTEST_ERROR;
+    }
+
+    if (item_list[1].item.uDataType == QCBOR_TYPE_TRUE)
+    {
+        *loop_back = true;
+    }
+
+    if (item_list[0].item.uDataType != QCBOR_TYPE_BYTE_STRING)
+    {
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+    }
+
+    *child = item_list[0].item.val.string;
+
+    return PAL_ATTEST_SUCCESS;
+}
+
+static int parse_protected_headers(struct useful_buf_c protected_headers,
+                                   int32_t *alg_id)
+{
+    QCBORDecodeContext  decode_context;
+    QCBORItem           item;
+
+    QCBORDecode_Init(&decode_context, protected_headers, 0);
+
+    if (get_item_in_map(&decode_context, COSE_HEADER_PARAM_ALG, &item))
+    {
+        return PAL_ATTEST_ERROR;
+    }
+
+    if (QCBORDecode_Finish(&decode_context))
+    {
+        return PAL_ATTEST_ERROR;
+    }
+
+    if ((item.uDataType != QCBOR_TYPE_INT64) || (item.val.int64 > INT32_MAX))
+    {
+        return PAL_ATTEST_ERROR;
+    }
+
+    *alg_id = (int32_t)item.val.int64;
+
+    return PAL_ATTEST_SUCCESS;
+}
+
+/**
+    @brief    - This API will verify the claims
+    @param    - decode_context      : The buffer containing the challenge
+                item                : context for decoding the data items
+                completed_challenge : Buffer containing the challenge
+    @return   - error status
+**/
+static int parse_claims(QCBORDecodeContext *decode_context, QCBORItem item,
+                                   struct useful_buf_c completed_challenge)
+{
+    int i, count = 0;
+    int status = PAL_ATTEST_SUCCESS;
+
+    /* Parse each claim and validate their data type */
+    while (status == PAL_ATTEST_SUCCESS)
+    {
+        status = QCBORDecode_GetNext(decode_context, &item);
+        if (status != PAL_ATTEST_SUCCESS)
+            break;
+
+        mandatory_claims |= 1 << (EAT_CBOR_ARM_RANGE_BASE - item.label.int64);
+        if (item.uLabelType == QCBOR_TYPE_INT64)
+        {
+            if (item.label.int64 == EAT_CBOR_ARM_LABEL_NONCE)
+            {
+                if (item.uDataType == QCBOR_TYPE_BYTE_STRING)
+                {
+                    /* Given challenge vs challenge in token */
+                    if (UsefulBuf_Compare(item.val.string, completed_challenge))
+                        return PAL_ATTEST_TOKEN_CHALLENGE_MISMATCH;
+                }
+                else
+                    return PAL_ATTEST_TOKEN_NOT_SUPPORTED;
+            }
+            else if (item.label.int64 == EAT_CBOR_ARM_LABEL_BOOT_SEED ||
+                     item.label.int64 == EAT_CBOR_ARM_LABEL_IMPLEMENTATION_ID ||
+                     item.label.int64 == EAT_CBOR_ARM_LABEL_UEID)
+            {
+                if (item.uDataType != QCBOR_TYPE_BYTE_STRING)
+                    return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+            }
+            else if (item.label.int64 == EAT_CBOR_ARM_LABEL_ORIGINATION ||
+                     item.label.int64 == EAT_CBOR_ARM_LABEL_PROFILE_DEFINITION ||
+                     item.label.int64 == EAT_CBOR_ARM_LABEL_HW_VERSION)
+            {
+                if (item.uDataType != QCBOR_TYPE_TEXT_STRING)
+                    return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+            }
+            else if (item.label.int64 == EAT_CBOR_ARM_LABEL_CLIENT_ID ||
+                     item.label.int64 == EAT_CBOR_ARM_LABEL_SECURITY_LIFECYCLE)
+            {
+                if (item.uDataType != QCBOR_TYPE_INT64)
+                    return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+            }
+            else if (item.label.int64 == EAT_CBOR_ARM_LABEL_SW_COMPONENTS)
+            {
+                if (item.uDataType != QCBOR_TYPE_ARRAY)
+                    return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+
+                sw_component_present = 1;
+                status = QCBORDecode_GetNext(decode_context, &item);
+                if (status != PAL_ATTEST_SUCCESS)
+                    continue;
+
+                count = item.val.uCount;
+                for (i = 0; i <= count; i++)
+                {
+                    mandaroty_sw_components |= 1 << item.label.int64;
+
+                    if (item.label.int64 == EAT_CBOR_SW_COMPONENT_MEASUREMENT)
+                    {
+                         if (item.uDataType != QCBOR_TYPE_BYTE_STRING)
+                            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+                    }
+                    else if (item.label.int64 == EAT_CBOR_SW_COMPONENT_MEASUREMENT_DESC)
+                    {
+                        if (item.uDataType != QCBOR_TYPE_TEXT_STRING)
+                            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+                    }
+                    else if (item.label.int64 == EAT_CBOR_SW_COMPONENT_VERSION)
+                    {
+                        if (item.uDataType != QCBOR_TYPE_TEXT_STRING)
+                            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+                    }
+                    else if (item.label.int64 == EAT_CBOR_SW_COMPONENT_SIGNER_ID)
+                    {
+                        if (item.uDataType != QCBOR_TYPE_BYTE_STRING)
+                            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+                    }
+                    else if (item.label.int64 == EAT_CBOR_SW_COMPONENT_EPOCH)
+                    {
+                        if (item.uDataType != QCBOR_TYPE_INT64)
+                            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+                    }
+                    else if (item.label.int64 == EAT_CBOR_SW_COMPONENT_TYPE)
+                    {
+                        if (item.uDataType != QCBOR_TYPE_TEXT_STRING)
+                            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+                    }
+
+                    if (i < count)
+                    {
+                        status = QCBORDecode_GetNext(decode_context, &item);
+                        if (status != PAL_ATTEST_SUCCESS)
+                            return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+                    }
+                }
+
+            }
+        }
+        else
+        {
+            /* ToDo: Add other claim types */
+        }
+    }
+
+    if (status == QCBOR_ERR_HIT_END)
+        return PAL_ATTEST_SUCCESS;
+    else
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+}
+
+/**
+    @brief    - This API will verify the attestation token
+    @param    - challenge       : The buffer containing the challenge
+                challenge_size  : Size of the challenge buffer
+                token           : The buffer containing the attestation token
+                token_size      : Size of the token buffer
+    @return   - error status
+**/
+int32_t pal_initial_attest_verify_token(uint8_t *challenge, uint32_t challenge_size,
+                                        uint8_t *token, uint32_t token_size)
+{
+    int                 status = PAL_ATTEST_SUCCESS;
+    bool                short_circuit;
+    int32_t             cose_algorithm_id;
+    QCBORItem           item;
+    QCBORDecodeContext  decode_context;
+    struct useful_buf_c completed_challenge;
+    struct useful_buf_c completed_token;
+    struct useful_buf_c payload;
+    struct useful_buf_c protected_headers;
+    struct useful_buf_c kid;
+
+    /* Construct the token buffer for validation */
+    completed_token.ptr = token;
+    completed_token.len = token_size;
+
+    /* Construct the challenge buffer for validation */
+    completed_challenge.ptr = challenge;
+    completed_challenge.len = challenge_size;
+
+/*
+    -------------------------
+    |  CBOR Array Type      |
+    -------------------------
+    |  Protected Headers    |
+    -------------------------
+    |  Unprotected Headers  |
+    -------------------------
+    |  Payload              |
+    -------------------------
+    |  Signature            |
+    -------------------------
+*/
+
+    /* Initialize the decorder */
+    QCBORDecode_Init(&decode_context, completed_token, QCBOR_DECODE_MODE_NORMAL);
+
+    /* Get the Header */
+    QCBORDecode_GetNext(&decode_context, &item);
+
+    /* Check the CBOR Array type. Check if the count is 4.
+     * Only COSE_SIGN1 is supported now.
+     */
+    if (item.uDataType != QCBOR_TYPE_ARRAY || item.val.uCount != 4 ||
+       !QCBORDecode_IsTagged(&decode_context, &item, CBOR_TAG_COSE_SIGN1))
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+
+    /* Get the next headers */
+    QCBORDecode_GetNext(&decode_context, &item);
+    if (item.uDataType != QCBOR_TYPE_BYTE_STRING)
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+
+    protected_headers = item.val.string;
+
+    /* Parse the protected headers and check the data type and value*/
+    status = parse_protected_headers(protected_headers, &cose_algorithm_id);
+    if (status != PAL_ATTEST_SUCCESS)
+        return status;
+
+    /* Parse the unprotected headers and check the data type and value */
+    short_circuit = false;
+    status = parse_unprotected_headers(&decode_context, &kid, &short_circuit);
+    if (status != PAL_ATTEST_SUCCESS)
+        return status;
+
+    /* Get the payload */
+    QCBORDecode_GetNext(&decode_context, &item);
+    if (item.uDataType != QCBOR_TYPE_BYTE_STRING)
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+
+    payload = item.val.string;
+
+    /* Get the digital signature */
+    QCBORDecode_GetNext(&decode_context, &item);
+    if (item.uDataType != QCBOR_TYPE_BYTE_STRING)
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+
+    /* Initialize the Decoder and validate the payload format */
+    QCBORDecode_Init(&decode_context, payload, QCBOR_DECODE_MODE_NORMAL);
+    status = QCBORDecode_GetNext(&decode_context, &item);
+    if (status != PAL_ATTEST_SUCCESS)
+        return status;
+
+    if (item.uDataType != QCBOR_TYPE_MAP)
+        return PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING;
+
+    /* Parse the payload and check the data type of each claim */
+    status = parse_claims(&decode_context, item, completed_challenge);
+    if (status != PAL_ATTEST_SUCCESS)
+        return status;
+
+    if ((mandatory_claims & MANDATORY_CLAIM_WITH_SW_COMP) == MANDATORY_CLAIM_WITH_SW_COMP)
+    {
+        if ((mandaroty_sw_components & MANDATORY_SW_COMP) != MANDATORY_SW_COMP)
+            return PAL_ATTEST_TOKEN_NOT_ALL_MANDATORY_CLAIMS;
+    }
+    else if ((mandatory_claims & MANDATORY_CLAIM_NO_SW_COMP) != MANDATORY_CLAIM_NO_SW_COMP)
+    {
+        return PAL_ATTEST_TOKEN_NOT_ALL_MANDATORY_CLAIMS;
+    }
+
+    return PAL_ATTEST_SUCCESS;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_eat.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_eat.h
@@ -1,0 +1,73 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "qcbor.h"
+#include "pal_common.h"
+
+#define PAL_ATTEST_MIN_ERROR              30
+
+#define COSE_HEADER_PARAM_ALG             1
+#define COSE_HEADER_PARAM_KID             4
+
+#define MANDATORY_CLAIM_WITH_SW_COMP      862
+#define MANDATORY_CLAIM_NO_SW_COMP        926
+#define MANDATORY_SW_COMP                 36
+#define CBOR_ARM_TOTAL_CLAIM_INSTANCE     10
+
+/*
+ CBOR Label for proprietary header indicating short-circuit
+ signing was used. Just a random number in the proprietary
+ label space */
+#define T_COSE_SHORT_CIRCUIT_LABEL              (-8675309)
+
+#define EAT_CBOR_ARM_RANGE_BASE                 (-75000)
+#define EAT_CBOR_ARM_LABEL_PROFILE_DEFINITION   (EAT_CBOR_ARM_RANGE_BASE - 0)
+#define EAT_CBOR_ARM_LABEL_CLIENT_ID            (EAT_CBOR_ARM_RANGE_BASE - 1)
+#define EAT_CBOR_ARM_LABEL_SECURITY_LIFECYCLE   (EAT_CBOR_ARM_RANGE_BASE - 2)
+#define EAT_CBOR_ARM_LABEL_IMPLEMENTATION_ID    (EAT_CBOR_ARM_RANGE_BASE - 3)
+#define EAT_CBOR_ARM_LABEL_BOOT_SEED            (EAT_CBOR_ARM_RANGE_BASE - 4)
+#define EAT_CBOR_ARM_LABEL_HW_VERSION           (EAT_CBOR_ARM_RANGE_BASE - 5)
+#define EAT_CBOR_ARM_LABEL_SW_COMPONENTS        (EAT_CBOR_ARM_RANGE_BASE - 6)
+#define EAT_CBOR_ARM_LABEL_NO_SW_COMPONENTS     (EAT_CBOR_ARM_RANGE_BASE - 7)
+#define EAT_CBOR_ARM_LABEL_NONCE                (EAT_CBOR_ARM_RANGE_BASE - 8)
+#define EAT_CBOR_ARM_LABEL_UEID                 (EAT_CBOR_ARM_RANGE_BASE - 9)
+#define EAT_CBOR_ARM_LABEL_ORIGINATION          (EAT_CBOR_ARM_RANGE_BASE - 10)
+
+#define EAT_CBOR_SW_COMPONENT_TYPE              (1u)
+#define EAT_CBOR_SW_COMPONENT_MEASUREMENT       (2u)
+#define EAT_CBOR_SW_COMPONENT_EPOCH             (3u)
+#define EAT_CBOR_SW_COMPONENT_VERSION           (4u)
+#define EAT_CBOR_SW_COMPONENT_SIGNER_ID         (5u)
+#define EAT_CBOR_SW_COMPONENT_MEASUREMENT_DESC  (6u)
+
+
+enum attestation_error_code {
+    PAL_ATTEST_SUCCESS = 0,
+    PAL_ATTEST_TOKEN_ERR_CBOR_FORMATTING = PAL_ATTEST_MIN_ERROR,
+    PAL_ATTEST_TOKEN_CHALLENGE_MISMATCH,
+    PAL_ATTEST_TOKEN_NOT_SUPPORTED,
+    PAL_ATTEST_TOKEN_NOT_ALL_MANDATORY_CLAIMS,
+    PAL_ATTEST_ERROR,
+};
+
+struct items_to_get_t {
+    int64_t label;
+    QCBORItem item;
+};
+
+int32_t pal_initial_attest_verify_token(uint8_t *challenge, uint32_t challenge_size,
+                                        uint8_t *token, uint32_t token_size);

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_empty_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_empty_intf.c
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include <stdarg.h>
+#include "pal_common.h"
+
+/**
+    @brief    - This API will call the requested attestation function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+int32_t pal_attestation_function(int type, va_list valist)
+{
+    return PAL_STATUS_ERROR;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_intf.c
@@ -1,0 +1,54 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+
+#include "pal_attestation_intf.h"
+
+/**
+    @brief    - This API will call the requested attestation function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+int32_t pal_attestation_function(int type, va_list valist)
+{
+    uint8_t     *challenge, *token;
+    uint32_t    challenge_size, *token_size, verify_token_size;
+
+    switch (type)
+    {
+        case PAL_INITIAL_ATTEST_GET_TOKEN:
+            challenge = va_arg(valist, uint8_t*);
+            challenge_size = va_arg(valist, uint32_t);
+            token = va_arg(valist, uint8_t*);
+            token_size = va_arg(valist, uint32_t*);
+            return psa_initial_attest_get_token(challenge, challenge_size, token, token_size);
+        case PAL_INITIAL_ATTEST_GET_TOKEN_SIZE:
+            challenge_size = va_arg(valist, uint32_t);
+            token_size = va_arg(valist, uint32_t*);
+            return psa_initial_attest_get_token_size(challenge_size, token_size);
+        case PAL_INITIAL_ATTEST_VERIFY_TOKEN:
+            challenge = va_arg(valist, uint8_t*);
+            challenge_size = va_arg(valist, uint32_t);
+            token = va_arg(valist, uint8_t*);
+            verify_token_size = va_arg(valist, uint32_t);
+            return pal_initial_attest_verify_token(challenge, challenge_size,
+                                                   token, verify_token_size);
+        default:
+            return PAL_STATUS_UNSUPPORTED_FUNC;
+    }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_intf.h
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_INITIAL_ATTESTATION_H_
+#define _PAL_INITIAL_ATTESTATION_H_
+
+#include "pal_attestation_eat.h"
+
+enum attestation_function_code {
+    PAL_INITIAL_ATTEST_GET_TOKEN        = 0x1,
+    PAL_INITIAL_ATTEST_GET_TOKEN_SIZE   = 0x2,
+    PAL_INITIAL_ATTEST_VERIFY_TOKEN     = 0x3,
+};
+
+int32_t pal_attestation_function(int type, va_list valist);
+#endif /* _PAL_INITIAL_ATTESTATION_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/internal_trusted_storage/pal_internal_trusted_storage_empty_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/internal_trusted_storage/pal_internal_trusted_storage_empty_intf.c
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include <stdarg.h>
+#include "pal_common.h"
+
+/**
+    @brief    - This API will call the requested internal trusted storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_its_function(int type, va_list valist)
+{
+    return PAL_STATUS_ERROR;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
@@ -1,0 +1,60 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+
+#include "pal_internal_trusted_storage_intf.h"
+
+/**
+    @brief    - This API will call the requested internal trusted storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_its_function(int type, va_list valist)
+{
+    psa_its_uid_t           uid;
+    uint32_t                data_length, offset;
+    const void              *p_write_data;
+    void                    *p_read_data;
+    psa_its_create_flags_t  its_create_flags;
+    struct psa_its_info_t   *its_p_info;
+
+    switch (type)
+    {
+    case PAL_ITS_SET:
+        uid = va_arg(valist, psa_its_uid_t);
+        data_length = va_arg(valist, uint32_t);
+        p_write_data = va_arg(valist, const void*);
+        its_create_flags = va_arg(valist, psa_its_create_flags_t);
+        return psa_its_set(uid, data_length, p_write_data, its_create_flags);
+    case PAL_ITS_GET:
+        uid = va_arg(valist, psa_its_uid_t);
+        offset = va_arg(valist, uint32_t);
+        data_length = va_arg(valist, uint32_t);
+        p_read_data = va_arg(valist, void*);
+        return psa_its_get(uid, offset, data_length, p_read_data);
+    case PAL_ITS_GET_INFO:
+        uid = va_arg(valist, psa_its_uid_t);
+        its_p_info = va_arg(valist, struct psa_its_info_t*);
+        return psa_its_get_info(uid, its_p_info);
+    case PAL_ITS_REMOVE:
+        uid = va_arg(valist, psa_its_uid_t);
+        return psa_its_remove(uid);
+    default:
+        return PAL_STATUS_UNSUPPORTED_FUNC;
+    }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.h
@@ -1,0 +1,31 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_INTERNAL_TRUSTED_STORAGE_INTF_H_
+#define _PAL_INTERNAL_TRUSTED_STORAGE_INTF_H_
+
+#include "pal_common.h"
+
+enum its_function_code {
+    PAL_ITS_SET                         = 0x1,
+    PAL_ITS_GET                         = 0x2,
+    PAL_ITS_GET_INFO                    = 0x3,
+    PAL_ITS_REMOVE                      = 0x4,
+};
+
+uint32_t pal_its_function(int type, va_list valist);
+#endif /* _PAL_INTERNAL_TRUSTED_STORAGE_INTF_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/protected_storage/pal_protected_storage_empty_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/protected_storage/pal_protected_storage_empty_intf.c
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include <stdarg.h>
+#include "pal_common.h"
+
+/**
+    @brief    - This API will call the requested protected storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_ps_function(int type, va_list valist)
+{
+    return PAL_STATUS_ERROR;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/protected_storage/pal_protected_storage_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/protected_storage/pal_protected_storage_intf.c
@@ -1,0 +1,75 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+
+#include "pal_protected_storage_intf.h"
+
+/**
+    @brief    - This API will call the requested protected storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_ps_function(int type, va_list valist)
+{
+    psa_ps_uid_t            uid;
+    uint32_t                data_length, size, offset;
+    const void              *p_write_data;
+    void                    *p_read_data;
+    psa_ps_create_flags_t   ps_create_flags;
+    struct psa_ps_info_t    *ps_p_info;
+
+    switch (type)
+    {
+     case PAL_PS_SET:
+         uid = va_arg(valist, psa_ps_uid_t);
+         data_length = va_arg(valist, uint32_t);
+         p_write_data = va_arg(valist, const void*);
+         ps_create_flags = va_arg(valist, psa_ps_create_flags_t);
+         return psa_ps_set(uid, data_length, p_write_data, ps_create_flags);
+     case PAL_PS_GET:
+         uid = va_arg(valist, psa_ps_uid_t);
+         offset = va_arg(valist, uint32_t);
+         data_length = va_arg(valist, uint32_t);
+         p_read_data = va_arg(valist, void*);
+         return psa_ps_get(uid, offset, data_length, p_read_data);
+     case PAL_PS_GET_INFO:
+         uid = va_arg(valist, psa_ps_uid_t);
+         ps_p_info = va_arg(valist, struct psa_ps_info_t*);
+         return psa_ps_get_info(uid, ps_p_info);
+     case PAL_PS_REMOVE:
+         uid = va_arg(valist, psa_ps_uid_t);
+         return psa_ps_remove(uid);
+     case PAL_PS_CREATE:
+         uid = va_arg(valist, psa_ps_uid_t);
+         size = va_arg(valist, uint32_t);
+         ps_create_flags = va_arg(valist, psa_ps_create_flags_t);
+         return psa_ps_create(uid, size, ps_create_flags);
+     case PAL_PS_SET_EXTENDED:
+         uid = va_arg(valist, psa_ps_uid_t);
+         offset = va_arg(valist, uint32_t);
+         data_length = va_arg(valist, uint32_t);
+         p_write_data = va_arg(valist, const void*);
+         return psa_ps_set_extended(uid, offset, data_length, p_write_data);
+     case PAL_PS_GET_SUPPORT:
+         return psa_ps_get_support();
+    default:
+        return PAL_STATUS_UNSUPPORTED_FUNC;
+    }
+
+    return PAL_STATUS_UNSUPPORTED_FUNC;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/protected_storage/pal_protected_storage_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/protected_storage/pal_protected_storage_intf.h
@@ -1,0 +1,34 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_PROTECTED_STORAGE_INTF_H_
+#define _PAL_PROTECTED_STORAGE_INTF_H_
+
+#include "pal_common.h"
+
+enum ps_function_code {
+    PAL_PS_SET                          = 0x1,
+    PAL_PS_GET                          = 0x2,
+    PAL_PS_GET_INFO                     = 0x3,
+    PAL_PS_REMOVE                       = 0x4,
+    PAL_PS_CREATE                       = 0x5,
+    PAL_PS_SET_EXTENDED                 = 0x6,
+    PAL_PS_GET_SUPPORT                  = 0x7,
+};
+
+uint32_t pal_ps_function(int type, va_list valist);
+#endif /* _PAL_PROTECTED_STORAGE_INTF_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/spe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/spe/pal_driver_intf.c
@@ -1,0 +1,111 @@
+ /** @file
+  * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+  * SPDX-License-Identifier : Apache-2.0
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+
+#include "pal_driver_intf.h"
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - void
+**/
+void pal_uart_init(uint32_t uart_base_addr)
+{
+    pal_uart_pl011_init(uart_base_addr);
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+**/
+
+void pal_print(char *str, uint32_t data)
+{
+  pal_uart_pl011_print(str,data);
+}
+
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - 1/0
+**/
+int pal_nvmem_write(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    return nvmem_write(base, offset, buffer, size);
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - base    : Base address of nvmem
+                offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - 1/0
+**/
+int pal_nvmem_read(addr_t base, uint32_t offset, void *buffer, int size)
+{
+    return nvmem_read(base, offset, buffer, size);
+}
+
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
+{
+    return(pal_wd_cmsdk_init(base_addr,time_us, timer_tick_us));
+
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_enable(addr_t base_addr)
+{
+    return(pal_wd_cmsdk_enable(base_addr));
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_disable(addr_t base_addr)
+{
+    return (pal_wd_cmsdk_disable(base_addr));
+}
+
+/**
+    @brief           - Checks whether hardware watchdog timer is enabled
+    @param           - base_addr       : Base address of the watchdog module
+    @return          - Enabled : 1, Disabled : 0
+**/
+int pal_wd_timer_is_enabled(addr_t base_addr)
+{
+    return (pal_wd_cmsdk_is_enabled(base_addr));
+}
+

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/spe/pal_driver_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/spe/pal_driver_intf.h
@@ -1,0 +1,33 @@
+ /** @file
+  * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+  * SPDX-License-Identifier : Apache-2.0
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *  http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+ **/
+
+#ifndef _PAL_DRIVER_INTF_H_
+#define _PAL_DRIVER_INTF_H_
+
+#include "pal_uart.h"
+#include "pal_nvmem.h"
+#include "pal_wd_cmsdk.h"
+
+void pal_uart_init(uint32_t uart_base_addr);
+void pal_print(char *str, uint32_t data);
+int pal_nvmem_write(addr_t base, uint32_t offset, void *buffer, int size);
+int pal_nvmem_read(addr_t base, uint32_t offset, void *buffer, int size);
+int pal_wd_timer_init(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us);
+int pal_wd_timer_enable(addr_t base_addr);
+int pal_wd_timer_disable(addr_t base_addr);
+int pal_wd_timer_is_enabled(addr_t base_addr);
+#endif /* _PAL_DRIVER_INTF_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/target.cfg
@@ -1,0 +1,56 @@
+///** @file
+// * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+// * SPDX-License-Identifier : Apache-2.0
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *  http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+//**/
+
+// UART device info
+uart.num=1;
+uart.0.base = 0x40106000; // UART1_NS
+uart.0.size = 0xFFF;
+uart.0.intr_id = 0xFF;
+uart.0.permission = TYPE_READ_WRITE;
+
+// Watchdog device info
+watchdog.num = 1;
+watchdog.0.base = 0x40081000;
+watchdog.0.size = 0xFFF;
+watchdog.0.intr_id = 0xFF;
+watchdog.0.permission = TYPE_READ_WRITE;
+watchdog.0.num_of_tick_per_micro_sec = 0x3;         //(sys_feq/1000000)
+watchdog.0.timeout_in_micro_sec_low = 0xF4240;      //1.0  sec :  1 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_medium = 0x1E8480;  //2.0  sec :  2 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_high = 0x4C4B40;    //5.0  sec :  5 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_crypto = 0x1312D00; //18.0 sec : 18 * 1000 * 1000
+
+// Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
+nvmem.num =1;
+nvmem.0.start = 0x20060000;
+nvmem.0.end = 0x200603FF;
+nvmem.0.permission = TYPE_READ_WRITE;
+
+// Miscellaneous - Test scatter info
+dut.num = 1;
+
+// Start address of 12KB NS memory for test ELF
+dut.0.ns_test_addr = 0x28110000;
+
+// Start address of combine_test_binary in memory. Memory can be main memory or secondary memory.
+// Size of combine_test_binary = Summation of size of each test ELF file.
+dut.0.ns_start_addr_of_combine_test_binary = 0x28120000;
+
+// Is combine_test_binary available in RAM?
+dut.0.combine_test_binary_in_ram = AVAILABLE;
+
+dut.0.implemented_psa_firmware_isolation_level = LEVEL1;


### PR DESCRIPTION
This commit creates the new target by copying all files from TF-M
Musca-A target and modifying the target.cfg file.