### PR TITLE
Attestation: Removing crypto hash implementation defined attributes

### DIFF
--- a/api-tests/dev_apis/crypto/test_c039/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c039/test_data.h
@@ -215,17 +215,20 @@ static test_data check1[] = {
 #endif
 #endif
 
-#ifdef FUTURE_SUPPORT
+#ifdef ARCH_TEST_ECDSA
+#ifdef ARCH_TEST_ECC_CURVE_SECP192R1
 {"Test psa_asymmetric_encrypt - ECC public key\n", 9,
- PSA_KEY_TYPE_ECC_PUBLIC_KEY_BASE | PSA_ECC_CURVE_SECP192R1,
+ PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP192R1),
 {0}, 75, PSA_KEY_USAGE_ENCRYPT, PSA_ALG_ECDSA_ANY,
 {0}, 0,
 {0xba, 0x78, 0x16, 0xbf, 0x8f, 0x01, 0xcf, 0xea, 0x41, 0x41, 0x40, 0xde, 0x5d,
  0xae, 0x22, 0x23, 0xb0, 0x03, 0x61, 0xa3, 0x96, 0x17, 0x7a, 0x9c, 0xb4, 0x10,
  0xff, 0x61, 0xf2, 0x00, 0x15, 0xad}, 22, 128,
  0, 192, PSA_SUCCESS
-}
+},
+#endif
 
+#ifdef ARCH_TEST_ECC_CURVE_SECP256R1
 {"Test psa_asymmetric_encrypt - ECC keypair\n", 10,
  PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP256R1),
 {0}, 97, PSA_KEY_USAGE_ENCRYPT, PSA_ALG_DETERMINISTIC_ECDSA(PSA_ALG_SHA_256),
@@ -235,6 +238,7 @@ static test_data check1[] = {
  0xff, 0x61, 0xf2, 0x00, 0x15, 0xad}, 22, 128,
  0, 192, PSA_SUCCESS
 }
+#endif
 #endif
 };
 

--- a/api-tests/platform/targets/tgt_dev_apis_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_crypto.h
+++ b/api-tests/platform/targets/tgt_dev_apis_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_crypto.h
@@ -47,19 +47,6 @@ static const struct ecc_public_key_t attest_public_key = {
       0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
 };
 
-struct pal_cose_crypto_hash {
-    union {
-        void    *ptr;
-        uint64_t handle;
-    } context;
-    int64_t status;
-};
-
-struct pal_cose_psa_crypto_hash {
-    psa_status_t         status;
-    psa_hash_operation_t operation;
-};
-
 static const uint8_t initial_attestation_public_x_key[] =
 {
     0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
@@ -84,10 +71,10 @@ static const ecc_key_t attest_key = {
         sizeof(initial_attestation_public_y_key)
 };
 
-int32_t pal_cose_crypto_hash_start(struct pal_cose_crypto_hash *hash_ctx, int32_t cose_hash_alg_id);
-void pal_cose_crypto_hash_update(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_start(psa_hash_operation_t *psa_hash, int32_t cose_hash_alg_id);
+void pal_cose_crypto_hash_update(psa_hash_operation_t *psa_hash,
                                  struct q_useful_buf_c data_to_hash);
-int32_t pal_cose_crypto_hash_finish(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_finish(psa_hash_operation_t *psa_hash,
                                     struct q_useful_buf buffer_to_hold_result,
                                     struct q_useful_buf_c *hash_result);
 int pal_create_sha256(struct q_useful_buf_c bytes_to_hash, struct q_useful_buf buffer_for_hash,

--- a/api-tests/platform/targets/tgt_dev_apis_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_eat.h
+++ b/api-tests/platform/targets/tgt_dev_apis_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_eat.h
@@ -140,7 +140,8 @@
                                                 1 << (EAT_CBOR_ARM_RANGE_BASE                      \
                                                     - EAT_CBOR_ARM_LABEL_NO_SW_COMPONENTS))
 
-#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT)
+#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT      |     \
+                                                1 << EAT_CBOR_SW_COMPONENT_SIGNER_ID)
 
 #define NULL_USEFUL_BUF_C  NULLUsefulBufC
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/initial_attestation/pal_attestation_crypto.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/initial_attestation/pal_attestation_crypto.h
@@ -47,19 +47,6 @@ static const struct ecc_public_key_t attest_public_key = {
       0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
 };
 
-struct pal_cose_crypto_hash {
-    union {
-        void    *ptr;
-        uint64_t handle;
-    } context;
-    int64_t status;
-};
-
-struct pal_cose_psa_crypto_hash {
-    psa_status_t         status;
-    psa_hash_operation_t operation;
-};
-
 static const uint8_t initial_attestation_public_x_key[] =
 {
     0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
@@ -84,10 +71,10 @@ static const ecc_key_t attest_key = {
         sizeof(initial_attestation_public_y_key)
 };
 
-int32_t pal_cose_crypto_hash_start(struct pal_cose_crypto_hash *hash_ctx, int32_t cose_hash_alg_id);
-void pal_cose_crypto_hash_update(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_start(psa_hash_operation_t *psa_hash, int32_t cose_hash_alg_id);
+void pal_cose_crypto_hash_update(psa_hash_operation_t *psa_hash,
                                  struct q_useful_buf_c data_to_hash);
-int32_t pal_cose_crypto_hash_finish(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_finish(psa_hash_operation_t *psa_hash,
                                     struct q_useful_buf buffer_to_hold_result,
                                     struct q_useful_buf_c *hash_result);
 int pal_create_sha256(struct q_useful_buf_c bytes_to_hash, struct q_useful_buf buffer_for_hash,

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/initial_attestation/pal_attestation_eat.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/initial_attestation/pal_attestation_eat.h
@@ -140,7 +140,8 @@
                                                 1 << (EAT_CBOR_ARM_RANGE_BASE                      \
                                                     - EAT_CBOR_ARM_LABEL_NO_SW_COMPONENTS))
 
-#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT)
+#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT      |     \
+                                                1 << EAT_CBOR_SW_COMPONENT_SIGNER_ID)
 
 #define NULL_USEFUL_BUF_C  NULLUsefulBufC
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/initial_attestation/pal_attestation_crypto.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/initial_attestation/pal_attestation_crypto.h
@@ -47,19 +47,6 @@ static const struct ecc_public_key_t attest_public_key = {
       0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
 };
 
-struct pal_cose_crypto_hash {
-    union {
-        void    *ptr;
-        uint64_t handle;
-    } context;
-    int64_t status;
-};
-
-struct pal_cose_psa_crypto_hash {
-    psa_status_t         status;
-    psa_hash_operation_t operation;
-};
-
 static const uint8_t initial_attestation_public_x_key[] =
 {
     0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
@@ -84,10 +71,10 @@ static const ecc_key_t attest_key = {
         sizeof(initial_attestation_public_y_key)
 };
 
-int32_t pal_cose_crypto_hash_start(struct pal_cose_crypto_hash *hash_ctx, int32_t cose_hash_alg_id);
-void pal_cose_crypto_hash_update(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_start(psa_hash_operation_t *psa_hash, int32_t cose_hash_alg_id);
+void pal_cose_crypto_hash_update(psa_hash_operation_t *psa_hash,
                                  struct q_useful_buf_c data_to_hash);
-int32_t pal_cose_crypto_hash_finish(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_finish(psa_hash_operation_t *psa_hash,
                                     struct q_useful_buf buffer_to_hold_result,
                                     struct q_useful_buf_c *hash_result);
 int pal_create_sha256(struct q_useful_buf_c bytes_to_hash, struct q_useful_buf buffer_for_hash,

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/initial_attestation/pal_attestation_eat.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/initial_attestation/pal_attestation_eat.h
@@ -140,7 +140,8 @@
                                                 1 << (EAT_CBOR_ARM_RANGE_BASE                      \
                                                     - EAT_CBOR_ARM_LABEL_NO_SW_COMPONENTS))
 
-#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT)
+#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT      |     \
+                                                1 << EAT_CBOR_SW_COMPONENT_SIGNER_ID)
 
 #define NULL_USEFUL_BUF_C  NULLUsefulBufC
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/initial_attestation/pal_attestation_crypto.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/initial_attestation/pal_attestation_crypto.h
@@ -47,19 +47,6 @@ static const struct ecc_public_key_t attest_public_key = {
       0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
 };
 
-struct pal_cose_crypto_hash {
-    union {
-        void    *ptr;
-        uint64_t handle;
-    } context;
-    int64_t status;
-};
-
-struct pal_cose_psa_crypto_hash {
-    psa_status_t         status;
-    psa_hash_operation_t operation;
-};
-
 static const uint8_t initial_attestation_public_x_key[] =
 {
     0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
@@ -84,10 +71,10 @@ static const ecc_key_t attest_key = {
         sizeof(initial_attestation_public_y_key)
 };
 
-int32_t pal_cose_crypto_hash_start(struct pal_cose_crypto_hash *hash_ctx, int32_t cose_hash_alg_id);
-void pal_cose_crypto_hash_update(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_start(psa_hash_operation_t *psa_hash, int32_t cose_hash_alg_id);
+void pal_cose_crypto_hash_update(psa_hash_operation_t *psa_hash,
                                  struct q_useful_buf_c data_to_hash);
-int32_t pal_cose_crypto_hash_finish(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_finish(psa_hash_operation_t *psa_hash,
                                     struct q_useful_buf buffer_to_hold_result,
                                     struct q_useful_buf_c *hash_result);
 int pal_create_sha256(struct q_useful_buf_c bytes_to_hash, struct q_useful_buf buffer_for_hash,

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/initial_attestation/pal_attestation_eat.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/initial_attestation/pal_attestation_eat.h
@@ -140,7 +140,8 @@
                                                 1 << (EAT_CBOR_ARM_RANGE_BASE                      \
                                                     - EAT_CBOR_ARM_LABEL_NO_SW_COMPONENTS))
 
-#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT)
+#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT      |     \
+                                                1 << EAT_CBOR_SW_COMPONENT_SIGNER_ID)
 
 #define NULL_USEFUL_BUF_C  NULLUsefulBufC
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_crypto.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_crypto.h
@@ -47,19 +47,6 @@ static const struct ecc_public_key_t attest_public_key = {
       0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
 };
 
-struct pal_cose_crypto_hash {
-    union {
-        void    *ptr;
-        uint64_t handle;
-    } context;
-    int64_t status;
-};
-
-struct pal_cose_psa_crypto_hash {
-    psa_status_t         status;
-    psa_hash_operation_t operation;
-};
-
 static const uint8_t initial_attestation_public_x_key[] =
 {
     0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
@@ -84,10 +71,10 @@ static const ecc_key_t attest_key = {
         sizeof(initial_attestation_public_y_key)
 };
 
-int32_t pal_cose_crypto_hash_start(struct pal_cose_crypto_hash *hash_ctx, int32_t cose_hash_alg_id);
-void pal_cose_crypto_hash_update(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_start(psa_hash_operation_t *psa_hash, int32_t cose_hash_alg_id);
+void pal_cose_crypto_hash_update(psa_hash_operation_t *psa_hash,
                                  struct q_useful_buf_c data_to_hash);
-int32_t pal_cose_crypto_hash_finish(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_finish(psa_hash_operation_t *psa_hash,
                                     struct q_useful_buf buffer_to_hold_result,
                                     struct q_useful_buf_c *hash_result);
 int pal_create_sha256(struct q_useful_buf_c bytes_to_hash, struct q_useful_buf buffer_for_hash,

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_eat.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/initial_attestation/pal_attestation_eat.h
@@ -140,7 +140,8 @@
                                                 1 << (EAT_CBOR_ARM_RANGE_BASE                      \
                                                     - EAT_CBOR_ARM_LABEL_NO_SW_COMPONENTS))
 
-#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT)
+#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT      |     \
+                                                1 << EAT_CBOR_SW_COMPONENT_SIGNER_ID)
 
 #define NULL_USEFUL_BUF_C  NULLUsefulBufC
 

--- a/api-tests/platform/targets/tgt_ff_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_crypto.h
+++ b/api-tests/platform/targets/tgt_ff_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_crypto.h
@@ -47,19 +47,6 @@ static const struct ecc_public_key_t attest_public_key = {
       0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
 };
 
-struct pal_cose_crypto_hash {
-    union {
-        void    *ptr;
-        uint64_t handle;
-    } context;
-    int64_t status;
-};
-
-struct pal_cose_psa_crypto_hash {
-    psa_status_t         status;
-    psa_hash_operation_t operation;
-};
-
 static const uint8_t initial_attestation_public_x_key[] =
 {
     0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
@@ -84,10 +71,10 @@ static const ecc_key_t attest_key = {
         sizeof(initial_attestation_public_y_key)
 };
 
-int32_t pal_cose_crypto_hash_start(struct pal_cose_crypto_hash *hash_ctx, int32_t cose_hash_alg_id);
-void pal_cose_crypto_hash_update(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_start(psa_hash_operation_t *psa_hash, int32_t cose_hash_alg_id);
+void pal_cose_crypto_hash_update(psa_hash_operation_t *psa_hash,
                                  struct q_useful_buf_c data_to_hash);
-int32_t pal_cose_crypto_hash_finish(struct pal_cose_crypto_hash *hash_ctx,
+int32_t pal_cose_crypto_hash_finish(psa_hash_operation_t *psa_hash,
                                     struct q_useful_buf buffer_to_hold_result,
                                     struct q_useful_buf_c *hash_result);
 int pal_create_sha256(struct q_useful_buf_c bytes_to_hash, struct q_useful_buf buffer_for_hash,

--- a/api-tests/platform/targets/tgt_ff_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_eat.h
+++ b/api-tests/platform/targets/tgt_ff_mbedos_fvp_mps2_m4/nspe/initial_attestation/pal_attestation_eat.h
@@ -140,7 +140,8 @@
                                                 1 << (EAT_CBOR_ARM_RANGE_BASE                      \
                                                     - EAT_CBOR_ARM_LABEL_NO_SW_COMPONENTS))
 
-#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT)
+#define MANDATORY_SW_COMP                      (1 << EAT_CBOR_SW_COMPONENT_MEASUREMENT      |     \
+                                                1 << EAT_CBOR_SW_COMPONENT_SIGNER_ID)
 
 #define NULL_USEFUL_BUF_C  NULLUsefulBufC
 


### PR DESCRIPTION
- The verification of token functionality in the attestation test suite makes assumption about the
  PSA hash structure which is implementation specific. No assumptions should be made on its
  content and are expected to be different for different implementations. Hence, modifying the
  the attributes in accordance with the PSA specification.
- Added missing crypto defines

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>