### PR TITLE
Fix redeclaration of "SECURE" when using Cortex-A

### DIFF
--- a/api-tests/ff/ipc/test_i001/test_i001.c
+++ b/api-tests/ff/ipc/test_i001/test_i001.c
@@ -71,8 +71,8 @@ int32_t client_test_psa_version(security_t caller)
 
    /* psa_version() check for implemented SID but allows only secure connection */
    version = psa->version(SERVER_SECURE_CONNECT_ONLY_SID);
-   if (((caller == NONSECURE) && (version != PSA_VERSION_NONE))
-       || ((caller == SECURE) && (version != 2)))
+   if (((caller == PSA_NONSECURE) && (version != PSA_VERSION_NONE))
+       || ((caller == PSA_SECURE) && (version != 2)))
    {
        status = VAL_STATUS_VERSION_API_FAILED;
        val->print(PRINT_ERROR,

--- a/api-tests/ff/ipc/test_i002/test_i002.c
+++ b/api-tests/ff/ipc/test_i002/test_i002.c
@@ -201,13 +201,13 @@ int32_t client_test_identity(security_t caller)
        status = VAL_STATUS_CALL_FAILED;
    }
    /* For NSPE access, identity should be < 0 */
-   else if ((caller == NONSECURE) && ((id_at_connect != id_at_call)
+   else if ((caller == PSA_NONSECURE) && ((id_at_connect != id_at_call)
             || (id_at_connect >=0) || (id_at_call >=0)))
    {
        status = VAL_STATUS_WRONG_IDENTITY;
    }
    /* For SPE access, identity should be > 0 */
-   else if ((caller == SECURE) && ((id_at_connect != id_at_call)
+   else if ((caller == PSA_SECURE) && ((id_at_connect != id_at_call)
             || (id_at_connect <=0) || (id_at_call <=0)))
    {
        status = VAL_STATUS_WRONG_IDENTITY;

--- a/api-tests/ff/ipc/test_i004/test_i004.c
+++ b/api-tests/ff/ipc/test_i004/test_i004.c
@@ -61,7 +61,7 @@ int32_t client_test_sid_does_not_exists(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -76,7 +76,7 @@ int32_t client_test_sid_does_not_exists(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_CONNECTION_REFUSED.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
+   if (caller == PSA_NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i005/test_i005.c
+++ b/api-tests/ff/ipc/test_i005/test_i005.c
@@ -61,7 +61,7 @@ int32_t client_test_strict_policy_higher_minor_version(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -78,7 +78,7 @@ int32_t client_test_strict_policy_higher_minor_version(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_CONNECTION_REFUSED.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
+   if (caller == PSA_NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i006/test_i006.c
+++ b/api-tests/ff/ipc/test_i006/test_i006.c
@@ -61,7 +61,7 @@ int32_t client_test_strict_policy_lower_minor_version(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -76,7 +76,7 @@ int32_t client_test_strict_policy_lower_minor_version(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_CONNECTION_REFUSED.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
+   if (caller == PSA_NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i007/test_i007.c
+++ b/api-tests/ff/ipc/test_i007/test_i007.c
@@ -61,7 +61,7 @@ int32_t client_test_relax_policy_higher_minor_version(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -76,7 +76,7 @@ int32_t client_test_relax_policy_higher_minor_version(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_CONNECTION_REFUSED.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
+   if (caller == PSA_NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i008/test_i008.c
+++ b/api-tests/ff/ipc/test_i008/test_i008.c
@@ -61,7 +61,7 @@ int32_t client_test_secure_access_only_connection(security_t caller)
     */
 
    /* Setting boot.state before test check for NS */
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
    {
        status = val->set_boot_flag(BOOT_EXPECTED_NS);
    }
@@ -77,7 +77,7 @@ int32_t client_test_secure_access_only_connection(security_t caller)
     */
    handle = psa->connect(SERVER_SECURE_CONNECT_ONLY_SID, 1);
 
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
    {
        /*
         * If the caller is in the NSPE, it is IMPLEMENTATION DEFINED whether

--- a/api-tests/ff/ipc/test_i010/test_i010.c
+++ b/api-tests/ff/ipc/test_i010/test_i010.c
@@ -62,7 +62,7 @@ int32_t client_test_unspecified_policy_with_higher_minor_ver(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -81,7 +81,7 @@ int32_t client_test_unspecified_policy_with_higher_minor_ver(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_CONNECTION_REFUSED.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
+   if (caller == PSA_NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i011/test_i011.c
+++ b/api-tests/ff/ipc/test_i011/test_i011.c
@@ -62,7 +62,7 @@ int32_t client_test_unspecified_policy_with_lower_minor_ver(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -81,7 +81,7 @@ int32_t client_test_unspecified_policy_with_lower_minor_ver(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_CONNECTION_REFUSED.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
+   if (caller == PSA_NONSECURE && handle == PSA_ERROR_CONNECTION_REFUSED)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i012/test_i012.c
+++ b/api-tests/ff/ipc/test_i012/test_i012.c
@@ -60,7 +60,7 @@ int32_t client_test_psa_close_with_invalid_handle(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -75,7 +75,7 @@ int32_t client_test_psa_close_with_invalid_handle(security_t caller)
     * a PROGRAMMER ERROR will panic or return with no effect.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i024/test_i024.c
+++ b/api-tests/ff/ipc/test_i024/test_i024.c
@@ -62,7 +62,7 @@ int32_t client_test_psa_call_with_invalid_handle(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -77,7 +77,7 @@ int32_t client_test_psa_call_with_invalid_handle(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i025/test_i025.c
+++ b/api-tests/ff/ipc/test_i025/test_i025.c
@@ -62,7 +62,7 @@ int32_t client_test_psa_call_with_null_handle(security_t caller)
     */
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -77,7 +77,7 @@ int32_t client_test_psa_call_with_null_handle(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        return VAL_STATUS_SUCCESS;
    }

--- a/api-tests/ff/ipc/test_i026/test_i026.c
+++ b/api-tests/ff/ipc/test_i026/test_i026.c
@@ -79,7 +79,7 @@ int32_t client_test_psa_call_with_iovec_more_than_max_limit(security_t caller)
    }
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -94,7 +94,7 @@ int32_t client_test_psa_call_with_iovec_more_than_max_limit(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        psa->close(handle);
        return VAL_STATUS_SUCCESS;

--- a/api-tests/ff/ipc/test_i027/test_i027.c
+++ b/api-tests/ff/ipc/test_i027/test_i027.c
@@ -71,7 +71,7 @@ int32_t client_test_psa_drop_connection(security_t caller)
    }
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -85,7 +85,7 @@ int32_t client_test_psa_drop_connection(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        /* Resetting boot.state to catch unwanted reboot */
        if (val->set_boot_flag(BOOT_NOT_EXPECTED))

--- a/api-tests/ff/ipc/test_i048/test_i048.c
+++ b/api-tests/ff/ipc/test_i048/test_i048.c
@@ -77,7 +77,7 @@ int32_t client_test_psa_call_with_invalid_invec_pointer(security_t caller)
    /*
     * Selection of invalid invec pointer:
     *
-    * if caller == NONSECURE
+    * if caller == PSA_NONSECURE
     *    // PSA RoT pointer
     *    invec_pointer = driver_mmio_region_base;
     * else
@@ -98,7 +98,7 @@ int32_t client_test_psa_call_with_invalid_invec_pointer(security_t caller)
        return status;
    }
 
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
        invalid_invec = (psa_invec *) memory_desc->start;
    else
    {
@@ -118,7 +118,7 @@ int32_t client_test_psa_call_with_invalid_invec_pointer(security_t caller)
    }
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -133,7 +133,7 @@ int32_t client_test_psa_call_with_invalid_invec_pointer(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        psa->close(handle);
        return VAL_STATUS_SUCCESS;

--- a/api-tests/ff/ipc/test_i049/test_i049.c
+++ b/api-tests/ff/ipc/test_i049/test_i049.c
@@ -77,7 +77,7 @@ int32_t client_test_psa_call_with_invalid_outvec_pointer(security_t caller)
    /*
     * Selection of invalid outvec pointer:
     *
-    * if caller == NONSECURE
+    * if caller == PSA_NONSECURE
     *    // PSA RoT pointer
     *    outvec_pointer = driver_mmio_region_base;
     * else
@@ -98,7 +98,7 @@ int32_t client_test_psa_call_with_invalid_outvec_pointer(security_t caller)
        return status;
    }
 
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
        invalid_outvec = (psa_outvec *) memory_desc->start;
    else
    {
@@ -118,7 +118,7 @@ int32_t client_test_psa_call_with_invalid_outvec_pointer(security_t caller)
    }
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -133,7 +133,7 @@ int32_t client_test_psa_call_with_invalid_outvec_pointer(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        psa->close(handle);
        return VAL_STATUS_SUCCESS;

--- a/api-tests/ff/ipc/test_i050/test_i050.c
+++ b/api-tests/ff/ipc/test_i050/test_i050.c
@@ -77,7 +77,7 @@ int32_t client_test_psa_call_with_invalid_invec_base(security_t caller)
    /*
     * Selection of invalid invec pointer:
     *
-    * if caller == NONSECURE
+    * if caller == PSA_NONSECURE
     *    // PSA RoT pointer
     *    invalid_base = driver_mmio_region_base;
     * else
@@ -98,7 +98,7 @@ int32_t client_test_psa_call_with_invalid_invec_base(security_t caller)
        return status;
    }
 
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
        invalid_base = (addr_t *) memory_desc->start;
    else
    {
@@ -118,7 +118,7 @@ int32_t client_test_psa_call_with_invalid_invec_base(security_t caller)
    }
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -135,7 +135,7 @@ int32_t client_test_psa_call_with_invalid_invec_base(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        psa->close(handle);
        return VAL_STATUS_SUCCESS;

--- a/api-tests/ff/ipc/test_i051/test_i051.c
+++ b/api-tests/ff/ipc/test_i051/test_i051.c
@@ -77,7 +77,7 @@ int32_t client_test_psa_call_with_invalid_outvec_base(security_t caller)
    /*
     * Selection of invalid outvec pointer:
     *
-    * if caller == NONSECURE
+    * if caller == PSA_NONSECURE
     *    // PSA RoT pointer
     *    invalid_base = driver_mmio_region_base;
     * else
@@ -98,7 +98,7 @@ int32_t client_test_psa_call_with_invalid_outvec_base(security_t caller)
        return status;
    }
 
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
        invalid_base = (addr_t *) memory_desc->start;
    else
    {
@@ -118,7 +118,7 @@ int32_t client_test_psa_call_with_invalid_outvec_base(security_t caller)
    }
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -135,7 +135,7 @@ int32_t client_test_psa_call_with_invalid_outvec_base(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        psa->close(handle);
        return VAL_STATUS_SUCCESS;

--- a/api-tests/ff/ipc/test_i052/test_i052.c
+++ b/api-tests/ff/ipc/test_i052/test_i052.c
@@ -78,7 +78,7 @@ int32_t client_test_psa_call_with_invalid_invec_end_addr(security_t caller)
    /*
     * Selection of invalid size for psa_invec:
     *
-    * if caller == NONSECURE
+    * if caller == PSA_NONSECURE
     *    valid_base = nspe_mmio_region_base;
     *    invalid_size = (driver_mmio_region_base - nspe_mmio_region_base + 1);
     * else
@@ -97,7 +97,7 @@ int32_t client_test_psa_call_with_invalid_invec_end_addr(security_t caller)
        return status;
    }
 
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
        memory_cfg_id = MEMORY_NSPE_MMIO;
    else
        memory_cfg_id = MEMORY_SERVER_PARTITION_MMIO;
@@ -116,7 +116,7 @@ int32_t client_test_psa_call_with_invalid_invec_end_addr(security_t caller)
    invalid_size = (memory_desc_driver->start - memory_desc->start + 1);
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -133,7 +133,7 @@ int32_t client_test_psa_call_with_invalid_invec_end_addr(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        psa->close(handle);
        return VAL_STATUS_SUCCESS;

--- a/api-tests/ff/ipc/test_i053/test_i053.c
+++ b/api-tests/ff/ipc/test_i053/test_i053.c
@@ -78,7 +78,7 @@ int32_t client_test_psa_call_with_invalid_outvec_end_addr(security_t caller)
    /*
     * Selection of invalid size for psa_outvec:
     *
-    * if caller == NONSECURE
+    * if caller == PSA_NONSECURE
     *    valid_base = nspe_mmio_region_base;
     *    invalid_size = (driver_mmio_region_base - nspe_mmio_region_base + 1);
     * else
@@ -97,7 +97,7 @@ int32_t client_test_psa_call_with_invalid_outvec_end_addr(security_t caller)
        return status;
    }
 
-   if (caller == NONSECURE)
+   if (caller == PSA_NONSECURE)
        memory_cfg_id = MEMORY_NSPE_MMIO;
    else
        memory_cfg_id = MEMORY_SERVER_PARTITION_MMIO;
@@ -116,7 +116,7 @@ int32_t client_test_psa_call_with_invalid_outvec_end_addr(security_t caller)
    invalid_size = (memory_desc_driver->start - memory_desc->start + 1);
 
    /* Setting boot.state before test check */
-   boot_state = (caller == NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
+   boot_state = (caller == PSA_NONSECURE) ? BOOT_EXPECTED_NS : BOOT_EXPECTED_S;
    if (val->set_boot_flag(boot_state))
    {
        val->print(PRINT_ERROR, "\tFailed to set boot flag before check\n", 0);
@@ -133,7 +133,7 @@ int32_t client_test_psa_call_with_invalid_outvec_end_addr(security_t caller)
     * a PROGRAMMER ERROR will panic or return PSA_ERROR_PROGRAMMER_ERROR.
     * For SPE caller, it must panic.
     */
-   if (caller == NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
+   if (caller == PSA_NONSECURE && status_of_call == PSA_ERROR_PROGRAMMER_ERROR)
    {
        psa->close(handle);
        return VAL_STATUS_SUCCESS;

--- a/api-tests/val/common/val.h
+++ b/api-tests/val/common/val.h
@@ -167,8 +167,8 @@
 
 /* enums */
 typedef enum {
-    NONSECURE = 0x0,
-    SECURE    = 0x1,
+    PSA_NONSECURE = 0x0,
+    PSA_SECURE    = 0x1,
 } security_t;
 
 typedef enum {

--- a/api-tests/val/nspe/val_framework.c
+++ b/api-tests/val/nspe/val_framework.c
@@ -159,7 +159,7 @@ val_status_t val_execute_non_secure_tests(uint32_t test_num, client_test_t *test
             }
 
             /* Execute client tests */
-            test_status = tests_list[i](NONSECURE);
+            test_status = tests_list[i](PSA_NONSECURE);
 
             if (server_hs == TRUE)
             {

--- a/api-tests/val/spe/val_partition_common.h
+++ b/api-tests/val/spe/val_partition_common.h
@@ -337,7 +337,7 @@ STATIC_DECLARE val_status_t val_execute_secure_tests(test_info_t test_info, clie
         }
 
         /* Execute client tests */
-        test_status = tests_list[i](SECURE);
+        test_status = tests_list[i](PSA_SECURE);
 
         /* Retrive Server test status */
         status = val_get_secure_test_result(&handle);


### PR DESCRIPTION
When using Cortex-A with mbed-os, the build fails because CMSIS defines the same name as ``SECURE``.
https://github.com/ARMmbed/mbed-os/issues/11256

So, I changed the enum name as follows.
``` .c
typedef enum {
    PSA_NONSECURE = 0x0,
    PSA_SECURE    = 0x1,
} security_t;
```