### PR TITLE
Crypto: Bug Fix: Removing referencing implementation defined structure

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -96,8 +96,6 @@ _check_arguments("TARGET")
 _check_arguments("SUITE")
 # Check for PSA_INCLUDE_PATHS command line argument
 _check_arguments("PSA_INCLUDE_PATHS")
-# Check for CPU_ARCH command line argument
-_check_arguments("CPU_ARCH")
 
 string(TOLOWER ${SUITE} SUITE_LOWER)
 
@@ -191,11 +189,16 @@ if(NOT DEFINED TOOLCHAIN)
         message(STATUS "[PSA] : Defaulting compiler to ${TOOLCHAIN}")
 endif()
 
-# Check for CPU architecture
-if(NOT ${CPU_ARCH} IN_LIST PSA_CPU_ARCH_SUPPORT)
-	message(FATAL_ERROR "[PSA] : Error: Unsupported value for -DCPU_ARCH=, supported CPU arch are : ${PSA_CPU_ARCH_SUPPORT}")
+if(${TOOLCHAIN} STREQUAL "ARMCLANG" OR ${TOOLCHAIN} STREQUAL "GNUARM")
+    if(NOT DEFINED CPU_ARCH)
+	    message(FATAL_ERROR "[PSA] : Error: -DCPU_ARCH option missing")
+    else()
+        # Check for CPU architecture
+        if(NOT ${CPU_ARCH} IN_LIST PSA_CPU_ARCH_SUPPORT)
+	        message(FATAL_ERROR "[PSA] : Error: Unsupported value for -DCPU_ARCH=, supported CPU arch are : ${PSA_CPU_ARCH_SUPPORT}")
+        endif()
+    endif()
 endif()
-
 
 # Check for VERBOSE
 if(NOT DEFINED VERBOSE)

--- a/api-tests/dev_apis/crypto/test_c002/test_c002.c
+++ b/api-tests/dev_apis/crypto/test_c002/test_c002.c
@@ -36,6 +36,7 @@ int32_t psa_import_key_test(caller_security_t caller)
     size_t                length;
     const uint8_t        *key_data;
     psa_key_type_t        get_key_type;
+    size_t                get_key_bits;
     int                   num_checks = sizeof(check1)/sizeof(check1[0]);
     psa_key_attributes_t  attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_attributes_t  get_attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -110,14 +111,11 @@ int32_t psa_import_key_test(caller_security_t caller)
                  &get_attributes);
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(4));
 
-        val->crypto_function(VAL_CRYPTO_GET_KEY_TYPE, &attributes, &get_key_type);
+        val->crypto_function(VAL_CRYPTO_GET_KEY_TYPE, &get_attributes, &get_key_type);
         TEST_ASSERT_EQUAL(get_key_type, check1[i].key_type, TEST_CHECKPOINT_NUM(5));
 
-        if (check1[i].attr_bits != 0)
-            TEST_ASSERT_EQUAL(get_attributes.bits, check1[i].attr_bits, TEST_CHECKPOINT_NUM(6));
-        else
-            TEST_ASSERT_EQUAL(get_attributes.bits, check1[i].expected_bit_length,
-                              TEST_CHECKPOINT_NUM(7));
+        val->crypto_function(VAL_CRYPTO_GET_KEY_BITS, &get_attributes, &get_key_bits);
+        TEST_ASSERT_EQUAL(get_key_bits, check1[i].expected_bit_length, TEST_CHECKPOINT_NUM(6));
 
         /* Export a key in binary format */
         status = val->crypto_function(VAL_CRYPTO_EXPORT_KEY, check1[i].key_handle, data,

--- a/api-tests/dev_apis/crypto/test_c006/test_c006.c
+++ b/api-tests/dev_apis/crypto/test_c006/test_c006.c
@@ -66,15 +66,15 @@ int32_t psa_hash_compute_test(caller_security_t caller)
         /* Calculate the hash (digest) of a message */
         status = val->crypto_function(VAL_CRYPTO_HASH_COMPUTE, check1[i].alg, &check1[i].input,
                  check1[i].input_length, hash, hash_size, &hash_length);
-        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(5));
+        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(3));
 
         if (check1[i].expected_status != PSA_SUCCESS)
         {
             continue;
         }
 
-        TEST_ASSERT_EQUAL(hash_length, PSA_HASH_SIZE(check1[i].alg), TEST_CHECKPOINT_NUM(7));
-        TEST_ASSERT_MEMCMP(hash, expected_hash, hash_length, TEST_CHECKPOINT_NUM(8));
+        TEST_ASSERT_EQUAL(hash_length, PSA_HASH_SIZE(check1[i].alg), TEST_CHECKPOINT_NUM(4));
+        TEST_ASSERT_MEMCMP(hash, expected_hash, hash_length, TEST_CHECKPOINT_NUM(5));
     }
 
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c014/test_c014.c
+++ b/api-tests/dev_apis/crypto/test_c014/test_c014.c
@@ -86,12 +86,12 @@ int32_t psa_hash_finish_test(caller_security_t caller)
             continue;
         }
 
-        TEST_ASSERT_EQUAL(hash_length, PSA_HASH_SIZE(check1[i].alg), TEST_CHECKPOINT_NUM(7));
-        TEST_ASSERT_MEMCMP(hash, expected_hash, hash_length, TEST_CHECKPOINT_NUM(8));
+        TEST_ASSERT_EQUAL(hash_length, PSA_HASH_SIZE(check1[i].alg), TEST_CHECKPOINT_NUM(6));
+        TEST_ASSERT_MEMCMP(hash, expected_hash, hash_length, TEST_CHECKPOINT_NUM(7));
 
         /*Abort the hash operation */
         status = val->crypto_function(VAL_CRYPTO_HASH_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
     }
 
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c016/test_c016.c
+++ b/api-tests/dev_apis/crypto/test_c016/test_c016.c
@@ -37,6 +37,7 @@ int32_t psa_generate_key_test(caller_security_t caller)
     psa_key_type_t        get_key_type;
     psa_key_usage_t       get_key_usage;
     psa_algorithm_t       get_key_alg;
+    size_t                get_key_bits;
     int                   num_checks = sizeof(check1)/sizeof(check1[0]);
     psa_key_attributes_t  attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_attributes_t  get_attributes = PSA_KEY_ATTRIBUTES_INIT;
@@ -82,25 +83,22 @@ int32_t psa_generate_key_test(caller_security_t caller)
         val->crypto_function(VAL_CRYPTO_GET_KEY_TYPE, &get_attributes, &get_key_type);
         TEST_ASSERT_EQUAL(get_key_type, check1[i].key_type, TEST_CHECKPOINT_NUM(5));
 
-        if (check1[i].attr_bits != 0)
-            TEST_ASSERT_EQUAL(get_attributes.bits, check1[i].attr_bits, TEST_CHECKPOINT_NUM(6));
-        else
-            TEST_ASSERT_EQUAL(get_attributes.bits, check1[i].expected_bit_length,
-                              TEST_CHECKPOINT_NUM(7));
+        val->crypto_function(VAL_CRYPTO_GET_KEY_BITS, &get_attributes, &get_key_bits);
+        TEST_ASSERT_EQUAL(get_key_bits, check1[i].expected_bit_length, TEST_CHECKPOINT_NUM(6));
 
         val->crypto_function(VAL_CRYPTO_GET_KEY_USAGE_FLAGS, &get_attributes, &get_key_usage);
-        TEST_ASSERT_EQUAL(get_key_usage, check1[i].usage, TEST_CHECKPOINT_NUM(8));
+        TEST_ASSERT_EQUAL(get_key_usage, check1[i].usage, TEST_CHECKPOINT_NUM(7));
 
         val->crypto_function(VAL_CRYPTO_GET_KEY_ALGORITHM, &get_attributes, &get_key_alg);
-        TEST_ASSERT_EQUAL(get_key_alg, check1[i].key_alg, TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_EQUAL(get_key_alg, check1[i].key_alg, TEST_CHECKPOINT_NUM(8));
 
         /* Export a key in binary format */
         status = val->crypto_function(VAL_CRYPTO_EXPORT_KEY, check1[i].key_handle, data,
                                       BUFFER_SIZE, &length);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
 
         /* Check the attributes of the exported key */
-        TEST_ASSERT_EQUAL(length, check1[i].expected_key_length, TEST_CHECKPOINT_NUM(11));
+        TEST_ASSERT_EQUAL(length, check1[i].expected_key_length, TEST_CHECKPOINT_NUM(10));
 
         /* Reset the attributes */
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
@@ -108,7 +106,7 @@ int32_t psa_generate_key_test(caller_security_t caller)
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(12));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(11));
     }
 
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c018/test_c018.c
+++ b/api-tests/dev_apis/crypto/test_c018/test_c018.c
@@ -180,17 +180,17 @@ int32_t psa_key_derivation_input_key_negative_test(caller_security_t caller)
 
         /* Abort the key derivation operation */
         status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         /* Set up a key derivation operation */
         status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_SETUP, &operation,
                  check2[i].alg);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         /* Provide an input for key derivation or key agreement */
         status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_INPUT_KEY, &operation,
                  check2[i].step, 0);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(6));
+        TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(7));
     }
 
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c022/test_c022.c
+++ b/api-tests/dev_apis/crypto/test_c022/test_c022.c
@@ -52,18 +52,18 @@ int32_t psa_key_derivation_abort_test(caller_security_t caller)
     val->print(PRINT_TEST, "Test psa_key_derivation_abort\n", 0);
 
     status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &func);
-    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(2));
-
-    status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &init);
     TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(3));
 
-    status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &zero);
+    status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &init);
     TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(4));
+
+    status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &zero);
+    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
     /* Read some data from a key derivation operation with no data in the operation */
     status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_OUTPUT_BYTES, &func, output,
              BUFFER_SIZE);
-    TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(5));
+    TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(6));
 
     return VAL_STATUS_SUCCESS;
 }

--- a/api-tests/dev_apis/crypto/test_c025/test_c025.c
+++ b/api-tests/dev_apis/crypto/test_c025/test_c025.c
@@ -100,28 +100,28 @@ int32_t psa_aead_decrypt_test(caller_security_t caller)
                   check1[i].key_alg, nonce, check1[i].nonce_length, additional_data,
                   check1[i].additional_data_length, check1[i].ciphertext, check1[i].ciphertext_size,
                   plaintext, check1[i].plaintext_size, &plaintext_length);
-        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(6));
+        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(4));
 
         if (check1[i].expected_status != PSA_SUCCESS)
         {
             /* Destroy the key */
             status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
             continue;
         }
 
         /* Check if the length matches */
         TEST_ASSERT_EQUAL(plaintext_length, check1[i].expected_plaintext_length,
-                          TEST_CHECKPOINT_NUM(8));
+                          TEST_CHECKPOINT_NUM(6));
 
         /* Check if the data matches */
         TEST_ASSERT_MEMCMP(plaintext, check1[i].expected_plaintext, plaintext_length,
-                           TEST_CHECKPOINT_NUM(9));
+                           TEST_CHECKPOINT_NUM(7));
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
 
         /* Reset the key attributes and check if psa_import_key fails */
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
@@ -131,7 +131,7 @@ int32_t psa_aead_decrypt_test(caller_security_t caller)
                   check1[i].key_alg, nonce, check1[i].nonce_length, additional_data,
                   check1[i].additional_data_length, check1[i].ciphertext, check1[i].ciphertext_size,
                   plaintext, check1[i].plaintext_size, &plaintext_length);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(11));
+        TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(9));
     }
 
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c026/test_c026.c
+++ b/api-tests/dev_apis/crypto/test_c026/test_c026.c
@@ -53,6 +53,10 @@ int32_t psa_mac_sign_setup_test(caller_security_t caller)
         val->print(PRINT_TEST, check1[i].test_desc, 0);
         memset(&operation, 0, sizeof(operation));
 
+        /* Setting up the watchdog timer for each check */
+        status = val->wd_reprogram_timer(WD_CRYPTO_TIMEOUT);
+        TEST_ASSERT_EQUAL(status, VAL_STATUS_SUCCESS, TEST_CHECKPOINT_NUM(2));
+
         /* Setup the attributes for the key */
         val->crypto_function(VAL_CRYPTO_SET_KEY_TYPE, &attributes, check1[i].key_type);
         val->crypto_function(VAL_CRYPTO_SET_KEY_USAGE_FLAGS, &attributes, check1[i].usage);
@@ -66,13 +70,13 @@ int32_t psa_mac_sign_setup_test(caller_security_t caller)
         /* Start a multipart MAC calculation operation */
         status = val->crypto_function(VAL_CRYPTO_MAC_SIGN_SETUP, &operation,
                     check1[i].key_handle, check1[i].key_alg);
-        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(6));
+        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(4));
 
         /* Whether setup succeeded or failed, abort must succeed.
            Abort a MAC operation
          */
         status = val->crypto_function(VAL_CRYPTO_MAC_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         /* If setup failed, reproduce the failure, so that the caller can
          * test the resulting state of the operation object.
@@ -81,12 +85,12 @@ int32_t psa_mac_sign_setup_test(caller_security_t caller)
         {
             status = val->crypto_function(VAL_CRYPTO_MAC_SIGN_SETUP, &operation,
                     check1[i].key_handle, check1[i].key_alg);
-            TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(8));
+            TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(6));
         }
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
 
         /* Reset the key attributes and check if psa_import_key fails */
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);

--- a/api-tests/dev_apis/crypto/test_c031/test_c031.c
+++ b/api-tests/dev_apis/crypto/test_c031/test_c031.c
@@ -71,19 +71,19 @@ int32_t psa_mac_abort_test(caller_security_t caller)
         /* Start a multipart MAC calculation operation */
         status = val->crypto_function(VAL_CRYPTO_MAC_SIGN_SETUP, &operation,
                     check1[i].key_handle, check1[i].key_alg);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(4));
 
         /* Abort a MAC operation */
         status = val->crypto_function(VAL_CRYPTO_MAC_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
         /* Multiple Abort a MAC operation should succeed */
         status = val->crypto_function(VAL_CRYPTO_MAC_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
     }
 
     return VAL_STATUS_SUCCESS;
@@ -131,24 +131,24 @@ int32_t psa_mac_abort_before_finish_test(caller_security_t caller)
 
     /* Start a multipart MAC calculation operation */
     status = val->crypto_function(VAL_CRYPTO_MAC_SIGN_SETUP, &operation, key_handle, key_alg);
-    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
+    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(4));
 
     /* Add a message fragment to a multipart MAC operation */
     status = val->crypto_function(VAL_CRYPTO_MAC_UPDATE, &operation, input_data, inputdata_size);
-    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
     /* Abort a MAC operation */
     status = val->crypto_function(VAL_CRYPTO_MAC_ABORT, &operation);
-    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
+    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
     /* Finish the calculation of the MAC of a message */
     status = val->crypto_function(VAL_CRYPTO_MAC_SIGN_FINISH, &operation, data,
                 BUFFER_SIZE, &length);
-    TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(9));
+    TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(7));
 
     /* Destroy the key */
     status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key_handle);
-    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
+    TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
 
     return VAL_STATUS_SUCCESS;
 }

--- a/api-tests/dev_apis/crypto/test_c038/test_c038.c
+++ b/api-tests/dev_apis/crypto/test_c038/test_c038.c
@@ -73,27 +73,27 @@ int32_t psa_cipher_abort_test(caller_security_t caller)
             /* Set the key for a multipart symmetric encryption operation */
             status = val->crypto_function(VAL_CRYPTO_CIPHER_ENCRYPT_SETUP, &operation,
                         check1[i].key_handle, check1[i].key_alg);
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(4));
         }
         else if (check1[i].usage == PSA_KEY_USAGE_DECRYPT)
         {
             /* Set the key for a multipart symmetric decryption operation */
             status = val->crypto_function(VAL_CRYPTO_CIPHER_DECRYPT_SETUP, &operation,
                         check1[i].key_handle, check1[i].key_alg);
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
         }
 
         /* Abort a cipher operation */
         status = val->crypto_function(VAL_CRYPTO_CIPHER_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
 
         /* Multiple abort cipher operation should return success*/
         status = val->crypto_function(VAL_CRYPTO_CIPHER_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
 
         /* Reset the key attributes and check if psa_import_key fails */
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);

--- a/api-tests/dev_apis/crypto/test_c040/test_c040.c
+++ b/api-tests/dev_apis/crypto/test_c040/test_c040.c
@@ -132,26 +132,26 @@ int32_t psa_asymmetric_decrypt_test(caller_security_t caller)
         status = val->crypto_function(VAL_CRYPTO_ASYMMTERIC_DECRYPT, check1[i].key_handle,
                     check1[i].key_alg, check1[i].input, check1[i].input_length, salt,
                     check1[i].salt_length, output, check1[i].output_size, &length);
-        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(6));
+        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(4));
 
         if (check1[i].expected_status != PSA_SUCCESS)
         {
             /* Destroy the key */
             status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
             continue;
         }
 
         /* Check if the output length matches with the expected length */
-        TEST_ASSERT_EQUAL(length, check1[i].expected_output_length, TEST_CHECKPOINT_NUM(8));
+        TEST_ASSERT_EQUAL(length, check1[i].expected_output_length, TEST_CHECKPOINT_NUM(6));
 
         /* Check if the output matches with the expected data */
-        TEST_ASSERT_MEMCMP(output, check1[i].expected_output, length, TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_MEMCMP(output, check1[i].expected_output, length, TEST_CHECKPOINT_NUM(7));
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
 
         /* Reset the key attributes and check if psa_import_key fails */
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);

--- a/api-tests/dev_apis/crypto/test_c041/test_c041.c
+++ b/api-tests/dev_apis/crypto/test_c041/test_c041.c
@@ -115,20 +115,20 @@ int32_t psa_asymmetric_sign_test(caller_security_t caller)
         {
             /* Destroy the key */
             status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
             continue;
         }
 
         /* Check if the output length matches with the expected length */
-        TEST_ASSERT_EQUAL(length, check1[i].expected_signature_length, TEST_CHECKPOINT_NUM(5));
+        TEST_ASSERT_EQUAL(length, check1[i].expected_signature_length, TEST_CHECKPOINT_NUM(6));
 
         /* Check if the output matches with the expected data */
-        TEST_ASSERT_MEMCMP(signature, check1[i].expected_signature, length, TEST_CHECKPOINT_NUM(6));
+        TEST_ASSERT_MEMCMP(signature, check1[i].expected_signature, length, TEST_CHECKPOINT_NUM(7));
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
     }
 
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c043/test_c043.c
+++ b/api-tests/dev_apis/crypto/test_c043/test_c043.c
@@ -86,7 +86,7 @@ int32_t psa_raw_key_agreement_test(caller_security_t caller)
 
         /* Destroy a key and restore the slot to its default state */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(14));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
     }
 
     return VAL_STATUS_SUCCESS;
@@ -115,7 +115,7 @@ int32_t psa_raw_key_agreement_negative_test(caller_security_t caller)
         status = val->crypto_function(VAL_CRYPTO_RAW_KEY_AGREEMENT, check2[i].key_alg,
                     check2[i].key_handle, check2[i].peer_key, check2[i].peer_key_length,
                     output, check2[i].output_size, &output_length);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(4));
+        TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(3));
 
         val->print(PRINT_TEST, "[Check %d] Test psa_raw_key_agreement - Zero as key handle\n",
                                                                                  g_test_count++);

--- a/api-tests/dev_apis/crypto/test_c050/test_c050.c
+++ b/api-tests/dev_apis/crypto/test_c050/test_c050.c
@@ -33,7 +33,7 @@ int32_t psa_open_key_test(caller_security_t caller)
 {
     int32_t               status, i = 0;
     uint8_t               data[BUFFER_SIZE];
-    size_t                length;
+    size_t                length, get_key_bits;
     const uint8_t        *key_data;
     psa_key_type_t        get_key_type;
     psa_key_usage_t       get_key_usage_flags;
@@ -183,38 +183,34 @@ int32_t psa_open_key_test(caller_security_t caller)
                      &get_attributes);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(16));
 
-            val->crypto_function(VAL_CRYPTO_GET_KEY_TYPE, &attributes, &get_key_type);
+            val->crypto_function(VAL_CRYPTO_GET_KEY_TYPE, &get_attributes, &get_key_type);
             TEST_ASSERT_EQUAL(get_key_type, check1[i].key_type, TEST_CHECKPOINT_NUM(17));
 
-            if (check1[i].attr_bits != 0)
-                TEST_ASSERT_EQUAL(get_attributes.bits, check1[i].attr_bits,
-                TEST_CHECKPOINT_NUM(18));
-            else
-                TEST_ASSERT_EQUAL(get_attributes.bits, check1[i].expected_bit_length,
-                TEST_CHECKPOINT_NUM(19));
+            val->crypto_function(VAL_CRYPTO_GET_KEY_BITS, &get_attributes, &get_key_bits);
+            TEST_ASSERT_EQUAL(get_key_bits, check1[i].expected_bit_length, TEST_CHECKPOINT_NUM(18));
 
             val->crypto_function(VAL_CRYPTO_GET_KEY_USAGE_FLAGS, &attributes, &get_key_usage_flags);
-            TEST_ASSERT_EQUAL(get_key_usage_flags, check1[i].usage, TEST_CHECKPOINT_NUM(20));
+            TEST_ASSERT_EQUAL(get_key_usage_flags, check1[i].usage, TEST_CHECKPOINT_NUM(19));
 
             val->crypto_function(VAL_CRYPTO_GET_KEY_ALGORITHM, &attributes, &get_key_algorithm);
-            TEST_ASSERT_EQUAL(get_key_algorithm, check1[i].key_alg, TEST_CHECKPOINT_NUM(21));
+            TEST_ASSERT_EQUAL(get_key_algorithm, check1[i].key_alg, TEST_CHECKPOINT_NUM(20));
 
             /* Export a key in binary format */
             status = val->crypto_function(VAL_CRYPTO_EXPORT_KEY, key_handle, data,
                                           BUFFER_SIZE, &length);
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(22));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(21));
 
             /* Check the value of the exported key */
-            TEST_ASSERT_EQUAL(length, check1[i].expected_key_length, TEST_CHECKPOINT_NUM(23));
+            TEST_ASSERT_EQUAL(length, check1[i].expected_key_length, TEST_CHECKPOINT_NUM(22));
 
             if (PSA_KEY_TYPE_IS_UNSTRUCTURED(check1[i].key_type))
             {
-                TEST_ASSERT_MEMCMP(data, check1[i].key_data, length, TEST_CHECKPOINT_NUM(24));
+                TEST_ASSERT_MEMCMP(data, check1[i].key_data, length, TEST_CHECKPOINT_NUM(23));
             }
             else if (PSA_KEY_TYPE_IS_RSA(check1[i].key_type)
                   || PSA_KEY_TYPE_IS_ECC(check1[i].key_type))
             {
-                TEST_ASSERT_MEMCMP(key_data, data, length, TEST_CHECKPOINT_NUM(25));
+                TEST_ASSERT_MEMCMP(key_data, data, length, TEST_CHECKPOINT_NUM(24));
             }
             else
             {
@@ -227,10 +223,10 @@ int32_t psa_open_key_test(caller_security_t caller)
             /* Save the check ID and set boot flags */
              ++i;
             status = val->nvmem_write(VAL_NVMEM_OFFSET(NV_TEST_DATA1), &i, sizeof(int32_t));
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(26));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(25));
 
             status = val->set_boot_flag(BOOT_NOT_EXPECTED);
-            TEST_ASSERT_EQUAL(status, VAL_STATUS_SUCCESS, TEST_CHECKPOINT_NUM(27));
+            TEST_ASSERT_EQUAL(status, VAL_STATUS_SUCCESS, TEST_CHECKPOINT_NUM(26));
 
         }
         else

--- a/api-tests/dev_apis/crypto/test_c055/test_c055.c
+++ b/api-tests/dev_apis/crypto/test_c055/test_c055.c
@@ -92,15 +92,15 @@ int32_t psa_aead_set_nonce_test(caller_security_t caller)
         /* Setting the nonce on an ongoing operation should be an error */
         status = val->crypto_function(VAL_CRYPTO_AEAD_SET_NONCE, &operation, check1[i].nonce,
                  check1[i].nonce_size);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE,  TEST_CHECKPOINT_NUM(9));
+        TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE,  TEST_CHECKPOINT_NUM(8));
 
         /* Abort the AEAD operation */
         status = val->crypto_function(VAL_CRYPTO_AEAD_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
 
         /* Destroy the key */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(11));
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
 
         /* Reset the key attributes */
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
@@ -108,7 +108,7 @@ int32_t psa_aead_set_nonce_test(caller_security_t caller)
         /* Setting the nonce on an aborted operation should be an error */
         status = val->crypto_function(VAL_CRYPTO_AEAD_SET_NONCE, &operation, check1[i].nonce,
                  check1[i].nonce_size);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE,  TEST_CHECKPOINT_NUM(12));
+        TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE,  TEST_CHECKPOINT_NUM(11));
 
     }
 

--- a/api-tests/docs/sw_requirements.md
+++ b/api-tests/docs/sw_requirements.md
@@ -5,7 +5,7 @@ Before starting the test suite build, ensure that the following requirements are
 
 - Host Operating System     : Ubuntu 16.04, Windows 10
 - Scripting tools           : Python 3.1.7
-- Compiler toolchain        : GNU Arm Embedded Toolchain 6.3.1, Arm Compiler v6.7
+- Compiler toolchain        : GNU Arm Embedded Toolchain 6.3.1, Arm Compiler v6.7, GCC 5.4.0 32-Bit (Linux Host), MinGW 6.3.0 32-Bit (Windows Host)
 - Build tools               : CMake 3.10
 
 **Note**: To compile the test suite code, at least one of the above supported compiler toolchains


### PR DESCRIPTION
- Few tests in the crypto test suite makes assumption about the PSA
  key attributes structure which is implementation specific. No
  assumptions should be made on its content and are expected to be
  different for different implementations. Hence, modifying the
  attributes in accordance with the PSA specification.

Signed-off-by: Gowtham Siddarth <gowtham.siddarth@arm.com>