### PR TITLE
Align PSA Storage tests with 1.0.0 spec

### DIFF
--- a/api-tests/dev_apis/internal_trusted_storage/test_s003/test_s003.c
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s003/test_s003.c
@@ -24,7 +24,7 @@
 #include "test_ps_data.h"
 #endif
 
-#define TEST_BUFF_SIZE 1024
+#define TEST_BUFF_SIZE 512
 #define NUM_ITERATIONS 2
 #define TEST_BASE_UID_VALUE UID_BASE_VALUE + 5
 

--- a/api-tests/dev_apis/internal_trusted_storage/test_s004/test_its_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s004/test_its_data.h
@@ -43,7 +43,7 @@ static const test_data s004_data[] = {
  VAL_ITS_SET, PSA_SUCCESS /* For same UID set the length as half of previous */
 },
 {
- VAL_ITS_GET, PSA_ERROR_INVALID_ARGUMENT /* Call get with incorrect length */
+ VAL_ITS_GET, PSA_SUCCESS /* Call get with incorrect length */
 },
 {
  0, 0 /* No data should be returned */

--- a/api-tests/dev_apis/internal_trusted_storage/test_s004/test_ps_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s004/test_ps_data.h
@@ -43,7 +43,7 @@ static const test_data s004_data[] = {
  VAL_PS_SET, PSA_SUCCESS /* For same UID set the length as half of previous */
 },
 {
- VAL_PS_GET, PSA_ERROR_INVALID_ARGUMENT /* Call get with incorrect length */
+ VAL_PS_GET, PSA_SUCCESS /* Call get with incorrect length */
 },
 {
  0, 0 /* No data should be returned */

--- a/api-tests/dev_apis/internal_trusted_storage/test_s004/test_s004.c
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s004/test_s004.c
@@ -61,12 +61,9 @@ int32_t psa_sst_get_data_check(caller_security_t caller)
     memset(read_buff, 0, TEST_BUFF_SIZE);
     status = SST_FUNCTION(s004_data[5].api, uid, 0, TEST_BUFF_SIZE, read_buff, &p_data_length);
     TEST_ASSERT_EQUAL(status, s004_data[5].status, TEST_CHECKPOINT_NUM(6));
-    for (j = 0; j < TEST_BUFF_SIZE; j++)
-    {
-        TEST_ASSERT_EQUAL(read_buff[j], 0, TEST_CHECKPOINT_NUM(7));
-    }
-    /* Expect p_data_length = 0,  when psa get function is not unsuccessful as in previous case */
-    TEST_ASSERT_EQUAL(p_data_length, 0, TEST_CHECKPOINT_NUM(8));
+    TEST_ASSERT_MEMCMP(read_buff, write_buff, TEST_BUFF_SIZE/2, TEST_CHECKPOINT_NUM(7));
+    /* Expect p_data_length = TEST_BUFF_SIZE/2, when psa get function is successful as in previous case */
+    TEST_ASSERT_EQUAL(p_data_length, TEST_BUFF_SIZE/2, TEST_CHECKPOINT_NUM(8));
 
     /* Call get function with CORRECT buffer length  */
     status = SST_FUNCTION(s004_data[7].api, uid, 0, TEST_BUFF_SIZE/2, read_buff, &p_data_length);

--- a/api-tests/dev_apis/internal_trusted_storage/test_s007/test_its_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s007/test_its_data.h
@@ -49,10 +49,10 @@ static const test_data s007_data[] = {
  VAL_ITS_SET, PSA_SUCCESS /* Decrease the length of storage */
 },
 {
- VAL_ITS_GET, PSA_ERROR_INVALID_ARGUMENT /* Try to access old length */
+ VAL_ITS_GET, PSA_SUCCESS /* Try to access old length */
 },
 {
- VAL_ITS_GET, PSA_ERROR_INVALID_ARGUMENT /* Try to access old length */
+ VAL_ITS_GET, PSA_SUCCESS /* Try to access old length */
 },
 {
  VAL_ITS_GET, PSA_SUCCESS /* Try to access data with correct length */

--- a/api-tests/dev_apis/internal_trusted_storage/test_s007/test_ps_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s007/test_ps_data.h
@@ -49,10 +49,10 @@ static const test_data s007_data[] = {
  VAL_PS_SET, PSA_SUCCESS /* Decrease the length of storage */
 },
 {
- VAL_PS_GET, PSA_ERROR_INVALID_ARGUMENT /* Try to access old length */
+ VAL_PS_GET, PSA_SUCCESS /* Try to access old length */
 },
 {
- VAL_PS_GET, PSA_ERROR_INVALID_ARGUMENT /* Try to access old length */
+ VAL_PS_GET, PSA_SUCCESS /* Try to access old length */
 },
 {
  VAL_PS_GET, PSA_SUCCESS /* Try to access data with correct length */

--- a/api-tests/dev_apis/internal_trusted_storage/test_s007/test_s007.c
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s007/test_s007.c
@@ -75,13 +75,13 @@ int32_t psa_sst_get_incorrect_size(caller_security_t caller)
     /* Access data using get API and old length */
     status = SST_FUNCTION(s007_data[7].api, uid, 0, TEST_BUFF_SIZE/2, read_buff, &p_data_length);
     TEST_ASSERT_EQUAL(status, s007_data[7].status, TEST_CHECKPOINT_NUM(9));
-    TEST_ASSERT_EQUAL(p_data_length, 0, TEST_CHECKPOINT_NUM(10));
+    TEST_ASSERT_EQUAL(p_data_length, TEST_BUFF_SIZE/4, TEST_CHECKPOINT_NUM(10));
 
     /* Access data using get API and old length */
     val->print(PRINT_TEST, "[Check 2] Call get API with old length\n", 0);
     status = SST_FUNCTION(s007_data[8].api, uid, 0, TEST_BUFF_SIZE, read_buff, &p_data_length);
     TEST_ASSERT_EQUAL(status, s007_data[8].status, TEST_CHECKPOINT_NUM(11));
-    TEST_ASSERT_EQUAL(p_data_length, 0, TEST_CHECKPOINT_NUM(12));
+    TEST_ASSERT_EQUAL(p_data_length, TEST_BUFF_SIZE/4, TEST_CHECKPOINT_NUM(12));
 
     /* Access data using correct length */
     val->print(PRINT_TEST, "[Check 3] Call get API with valid length\n", 0);

--- a/api-tests/dev_apis/internal_trusted_storage/test_s008/test_its_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s008/test_its_data.h
@@ -52,13 +52,13 @@ static const test_data s008_data[] = {
  0, 0 /* This is dummy for index7 */
 },
 {
- VAL_ITS_GET, PSA_ERROR_INVALID_ARGUMENT /* get API with offset + data_len > total data_size */
+ VAL_ITS_GET, PSA_SUCCESS /* get API with offset + data_len > total data_size */
 },
 {
  0, 0 /* This is dummy for index9 */
 },
 {
- VAL_ITS_GET, PSA_ERROR_INVALID_ARGUMENT /* Call get API with invalid data len and offset zero */
+ VAL_ITS_GET, PSA_SUCCESS /* Call get API with invalid data len and offset zero */
 },
 {
  0, 0 /* This is dummy for index11 */

--- a/api-tests/dev_apis/internal_trusted_storage/test_s008/test_ps_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s008/test_ps_data.h
@@ -52,19 +52,19 @@ static const test_data s008_data[] = {
  0, 0 /* This is dummy for index7 */
 },
 {
- VAL_PS_GET, PSA_ERROR_INVALID_ARGUMENT /* Call get API with offset + data_len > total data_size */
+ VAL_PS_GET, PSA_SUCCESS /* Call get API with offset + data_len > total data_size */
 },
 {
  0, 0 /* This is dummy for index9 */
 },
 {
- VAL_PS_GET, PSA_ERROR_INVALID_ARGUMENT /* Call get API with invalid data len and offset zero */
+ VAL_PS_GET, PSA_SUCCESS /* Call get API with invalid data len and offset zero */
 },
 {
  0, 0 /* This is dummy for index11 */
 },
 {
- VAL_PS_GET, PSA_SUCCESS /* Call get API with offset = MAX_UINT32 */
+ VAL_PS_GET, PSA_ERROR_INVALID_ARGUMENT /* Call get API with offset = MAX_UINT32 */
 },
 {
  VAL_PS_REMOVE, PSA_SUCCESS /* Remove the storage entity */

--- a/api-tests/dev_apis/internal_trusted_storage/test_s008/test_s008.c
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s008/test_s008.c
@@ -66,16 +66,13 @@ int32_t psa_sst_invalid_offset_failure(caller_security_t caller)
     /* Case where offset = 0  , data_len > data_size  Also check nothing is returned in read buff*/
     status = SST_FUNCTION(s008_data[10].api, uid, 0, TEST_BUFF_SIZE+1, read_buff, &p_data_length);
     TEST_ASSERT_EQUAL(status, s008_data[10].status, TEST_CHECKPOINT_NUM(14));
-    TEST_ASSERT_EQUAL(p_data_length, 0, TEST_CHECKPOINT_NUM(15));
-    for (j = 0; j < TEST_BUFF_SIZE; j++)
-    {
-        TEST_ASSERT_EQUAL(read_buff[j], 0x00, TEST_CHECKPOINT_NUM(16));
-    }
+    TEST_ASSERT_EQUAL(p_data_length, TEST_BUFF_SIZE, TEST_CHECKPOINT_NUM(15));
+    TEST_ASSERT_MEMCMP(read_buff, write_buff, TEST_BUFF_SIZE, TEST_CHECKPOINT_NUM(16));
 
     /* Try to access data with offset as MAX_UINT32 and length less than buffer size */
     status = SST_FUNCTION(s008_data[12].api, uid, TEST_MAX_UINT32, TEST_BUFF_SIZE/2, read_buff,
                           &p_data_length);
-    TEST_ASSERT_NOT_EQUAL(status, s008_data[12].status, TEST_CHECKPOINT_NUM(17));
+    TEST_ASSERT_EQUAL(status, s008_data[12].status, TEST_CHECKPOINT_NUM(17));
 
     /* Remove the UID */
     status = SST_FUNCTION(s008_data[13].api, uid);


### PR DESCRIPTION
This pull request updates the PSA Internal Trusted Storage tests to take account of the fact that the latest spec allows the client to request more data than the uid's size. In this case, the implementation will read up to the end of the data, and then return the actual amount read (which will be less than requested) in `p_data_length`. Using an `offset` that is larger than the uid's size is still an invalid argument.

Also reduces a buff size to 512 bytes, as this is the default max size for the TF-M ITS implementation. We expect nothing larger than a 4096-bit RSA key will need to be stored in ITS for most use cases.

I have tested this with the TF-M ITS implementation on review here: https://review.trustedfirmware.org/c/trusted-firmware-m/+/1730