### PR TITLE
Add missing test suite build option information

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -45,9 +45,12 @@ list(APPEND PSA_SUITES
 list(APPEND PSA_IPC_FILES
 	"psa/client.h"
 	"psa/service.h"
+	"psa/lifecycle.h"
 	"psa_manifest/sid.h"
 	"psa_manifest/pid.h"
-	"psa/lifecycle.h"
+	"psa_manifest/driver_partition_psa.h"
+	"psa_manifest/client_partition_psa.h"
+	"psa_manifest/server_partition_psa.h"
 )
 
 # list of crypto files required
@@ -224,13 +227,13 @@ else()
 endif()
 
 if(NOT DEFINED WATCHDOG_AVAILABLE)
-	set(WATCHDOG_AVAILABLE	1 CACHE INTERNAL "By default watchdog is enabled" FORCE)
-        message(STATUS "[PSA] : Watchdog is enabled by default")
+	set(WATCHDOG_AVAILABLE	1 CACHE INTERNAL "Assuming watchdog is available to program by test suite" FORCE)
+        message(STATUS "[PSA] : Watchdog is available by default")
 endif()
 
 if((INCLUDE_PANIC_TESTS EQUAL 1) AND
    (WATCHDOG_AVAILABLE EQUAL 0))
-	message(FATAL_ERROR "[PSA]: Panic test execution needs watchdog to be enabled! set -DWATCHDOG_AVAILABLE=1")
+	message(FATAL_ERROR "[PSA]: Panic test execution needs watchdog access. set -DWATCHDOG_AVAILABLE=1")
 endif()
 
 if(NOT DEFINED SP_HEAP_MEM_SUPP)

--- a/api-tests/dev_apis/README.md
+++ b/api-tests/dev_apis/README.md
@@ -34,17 +34,23 @@ To build the test suite for your target platform, execute the following commands
     cd api-tests
     mkdir <build_dir>
     cd <build_dir>
-    cmake ../ -G"<generator-name> -DTARGET=<platform_name> -DCPU_ARCH=<cpu_architecture_version> -DSUITE=<suite_name> -DPSA_INCLUDE_PATHS="<include_path1>;<include_path2>;...;<include_pathn>"
+    cmake ../ -G"<generator_name>" -DTARGET=<platform_name> -DCPU_ARCH=<cpu_architecture_version> -DSUITE=<suite_name> -DPSA_INCLUDE_PATHS="<include_path1>;<include_path2>;...;<include_pathn>"
     cmake --build .
 ```
-<br />  where:
+<br />Options information:<br />
 
--   <generator-name> "Unix Makefiles" to generate Makefiles for Linux and Cygwin <br />
-                     "MinGW Makefiles" to generate Makefiles for cmd.exe on Windows  <br />
--   <platform_name> is the same as the name of the target-specific directory created in the **platform/targets/** directory. The current release has been tested on **tgt_dev_apis_tfm_an521**, **tgt_dev_apis_tfm_musca_b1** and **tgt_dev_apis_tfm_musca_a** platforms.<br />
--   <cpu_architecture_version> is the Arm Architecture version name for which the tests should be compiled. For example, Armv7M, Armv8M-Baseline and Armv8M-Mainline Architecture.  <br />
--   <suite_name> is the suite name that is the same as the suite name available in **dev_apis/** directory. <br />
--   <include_path1>;<include_path2>;...;<include_pathn> is an additional directory to be included into the compiler search path.You must provide Developer APIs header file implementation to the test suite build system using this option. For example, to compile Crypto tests, the include path must point to the path where **psa/crypto.h** is located in your build system.<br />
+-   -G"<generator_name>" : "Unix Makefiles" to generate Makefiles for Linux and Cygwin. "MinGW Makefiles" to generate Makefiles for cmd.exe on Windows  <br />
+-   -DTARGET=<platform_name> is the same as the name of the target-specific directory created in the **platform/targets/** directory. The current release has been tested on **tgt_dev_apis_tfm_an521**, **tgt_dev_apis_tfm_musca_b1** and **tgt_dev_apis_tfm_musca_a** platforms.<br />
+-   -DTOOLCHAIN=<tool_chain> Compiler toolchain to be used for test suite compilation. Supported values are GNUARM (GNU Arm Embedded), ARMCLANG (ARM Compiler 6.x) and HOST_GCC. Default is GNUARM.<br />
+-   -DCPU_ARCH=<cpu_architecture_version> is the Arm Architecture version name for which the tests should be compiled. Supported CPU arch are armv8m_ml, armv8m_bl and armv7m. Default is empty. This option is unused when TOOLCHAIN type is HOST_GCC.<br />
+-   -DSUITE=<suite_name> is the suite name that is the same as the suite name available in **dev_apis/** directory.<br />
+-   -DVERBOSE=<verbose_level>. Print verbosity level. Default is 3. Supported print levels are 1(INFO & above), 2(DEBUG & above), 3(TEST & above), 4(WARN & ERROR) and 5(ERROR).
+-   -DBUILD=<BUILD_DIR> : To select the build directory to keep output files. Default is BUILD/ inside current directory.
+-   -DWATCHDOG_AVAILABLE=<0|1>: Test harness may require to access watchdog timer to recover system hang. 0 means skip watchdog programming in the test suite and 1 means program the watchdog. Default is 1. Note, watchdog must be available for the tests which depend on the system reset conditions.
+-   -DPSA_INCLUDE_PATHS="<include_path1>;<include_path2>;...;<include_pathn>" is an additional directory to be included into the compiler search path.You must provide Developer APIs header files implementation to the test suite build system using this option. For example, to compile Crypto tests, the include path must point to the path where **psa/crypto.h** is located in your build system. Bydefault, PSA_INCLUDE_PATHS accepts absolute path. However, relative path can be provided using below format:<br />
+```
+    -DPSA_INCLUDE_PATHS=`readlink -f <relative_include_path>`
+```
 
 To compile Crypto tests for **tgt_dev_apis_tfm_an521** platform, execute the following commands:
 ```

--- a/api-tests/ff/README.md
+++ b/api-tests/ff/README.md
@@ -52,17 +52,26 @@ To build the test suite for your target platform, perform the following steps.
     cd api-tests
     mkdir <build_dir>
     cd <build_dir>
-    cmake ../ -G"<generator-name> -DTARGET=<platform_name> -DCPU_ARCH=<cpu_architecture_version> -DSUITE=<suite_name> -DPSA_INCLUDE_PATHS="<include_path1>;<include_path2>;...;<include_pathn>"
+    cmake ../ -G"<generator_name>" -DTARGET=<platform_name> -DCPU_ARCH=<cpu_architecture_version> -DSUITE=<suite_name> -DPSA_INCLUDE_PATHS="<include_path1>;<include_path2>;...;<include_pathn>"
     cmake --build .
 ```
-<br />  where:
+<br />Options information:<br />
 
--   <generator-name> "Unix Makefiles" to generate Makefiles for Linux and Cygwin <br />
-                     "MinGW Makefiles" to generate Makefiles for cmd.exe on Windows  <br />
--   <platform_name> is the same as the name of the target specific directory created in the **platform/targets/** directory.  <br />
--   <cpu_architecture_version> is the Arm Architecture version name for which the tests should be compiled. For example, Armv7M, Armv8M-Baseline and Armv8M-Mainline Architecture.  <br />
--   <suite_name> is the suite name which is the same as the suite name available in **ff/** directory. <br >
--   <include_path1>;<include_path2>;...;<include_pathn> is an additional directory to be included into the compiler search path. To compile IPC tests, the include path must point to the path where **psa/client.h**, **psa/service.h**,  **psa/lifecycle.h** and test partition manifest output files(**psa_manifest/sid.h**, **psa_manifest/pid.h** and **psa_manifest/<manifestfilename>.h**) are located in your build system.<br />
+-   -G"<generator_name>" : "Unix Makefiles" to generate Makefiles for Linux and Cygwin. "MinGW Makefiles" to generate Makefiles for cmd.exe on Windows  <br />
+-   -DTARGET=<platform_name> is the same as the name of the target-specific directory created in the **platform/targets/** directory. The current release has been tested on **tgt_dev_apis_tfm_an521**, **tgt_dev_apis_tfm_musca_b1** and **tgt_dev_apis_tfm_musca_a** platforms.<br />
+-   -DTOOLCHAIN=<tool_chain> Compiler toolchain to be used for test suite compilation. Supported values are GNUARM (GNU Arm Embedded), ARMCLANG (ARM Compiler 6.x) and HOST_GCC. Default is GNUARM.<br />
+-   -DCPU_ARCH=<cpu_architecture_version> is the Arm Architecture version name for which the tests should be compiled. Supported CPU arch are armv8m_ml, armv8m_bl and armv7m. Default is empty. This option is unused when TOOLCHAIN type is HOST_GCC.<br />
+-   -DSUITE=<suite_name> is the suite name which is the same as the suite name available in **ff/** directory. <br >
+-   -DVERBOSE=<verbose_level>. Print verbosity level. Default is 3. Supported print levels are 1(INFO & above), 2(DEBUG & above), 3(TEST & above), 4(WARN & ERROR) and 5(ERROR).
+-   -DBUILD=<BUILD_DIR> : To select the build directory to keep output files. Default is BUILD/ inside current directory.
+-   -DINCLUDE_PANIC_TESTS=<0|1> : The default compilation flow includes the functional API tests to build the test suite. It does not include panic tests that check for the API's PROGRAMMER ERROR conditions as defined in the PSA-FF specification. You can include the panic tests for building the test suite by setting this option to 1.
+-   -DPLATFORM_PSA_ISOLATION_LEVEL=<1|2|3> : PSA Firmware Framwork isolation level supported by the platform. Default is highest level of isolation which is three.
+-   -DSP_HEAP_MEM_SUPP=<0|1> : Are dynamic memory functions available to secure partition? 0 means no and 1 means yes.
+-   -DWATCHDOG_AVAILABLE=<0|1>: Test harness may require to access watchdog timer to recover system hang. 0 means skip watchdog programming in the test suite and 1 means program the watchdog. Default is 1. Note, watchdog must be available for the tests which test the panic conditions.
+-   -DPSA_INCLUDE_PATHS="<include_path1>;<include_path2>;...;<include_pathn>" is an additional directory to be included into the compiler search path. To compile IPC tests, the include path must point to the path where **psa/client.h**, **psa/service.h**,  **psa/lifecycle.h** and test partition manifest output files(**psa_manifest/sid.h**, **psa_manifest/pid.h** and **psa_manifest/<manifestfilename>.h**) are located in your build system. Bydefault, PSA_INCLUDE_PATHS accepts absolute path. However, relative path can be provided using below format:<br />
+```
+    -DPSA_INCLUDE_PATHS=`readlink -f <relative_include_path>`
+```
 
 To compile IPC tests for **tgt_ff_tfm_an521** platform, execute the following commands:
 ```

--- a/api-tests/val/common/val_target.h
+++ b/api-tests/val/common/val_target.h
@@ -204,6 +204,5 @@ STATIC_DECLARE val_status_t val_target_get_config(cfg_id_t cfg_id, uint8_t **dat
 STATIC_DECLARE val_status_t val_target_cfg_get_next(void **blob);
 STATIC_DECLARE val_status_t val_target_get_cfg_blob(cfg_id_t cfg_id, uint8_t **data,
                                                     uint32_t *size);
-STATIC_DECLARE val_status_t val_target_get_config(cfg_id_t cfg_id, uint8_t **data, uint32_t *size);
 #endif
 #endif


### PR DESCRIPTION
- Add missing test suite build option information
- Fix for https://github.com/ARM-software/psa-arch-tests/issues/128
- Fix duplicate function declaration: https://github.com/ARM-software/psa-arch-tests/issues/130