### PR TITLE
Add Support for PSA Internal Trusted Storage (ITS) and Protect Storage (PS) Testing

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/internal_trusted_storage/pal_internal_trusted_storage_empty_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/internal_trusted_storage/pal_internal_trusted_storage_empty_intf.c
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include <stdarg.h>
+#include "pal_common.h"
+
+/**
+    @brief    - This API will call the requested internal trusted storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_its_function(int type, va_list valist)
+{
+    return PAL_STATUS_ERROR;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
@@ -1,0 +1,62 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+
+#include "pal_internal_trusted_storage_intf.h"
+
+/**
+    @brief    - This API will call the requested internal trusted storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_its_function(int type, va_list valist)
+{
+    psa_storage_uid_t           uid;
+    uint32_t                    data_size, offset;
+    const void                  *p_write_data;
+    void                        *p_read_data;
+    size_t                      *p_data_length;
+    psa_storage_create_flags_t  its_create_flags;
+    struct psa_storage_info_t   *its_p_info;
+
+    switch (type)
+    {
+    case PAL_ITS_SET:
+        uid = va_arg(valist, psa_storage_uid_t);
+        data_size = va_arg(valist, uint32_t);
+        p_write_data = va_arg(valist, const void*);
+        its_create_flags = va_arg(valist, psa_storage_create_flags_t);
+        return psa_its_set(uid, data_size, p_write_data, its_create_flags);
+    case PAL_ITS_GET:
+        uid = va_arg(valist, psa_storage_uid_t);
+        offset = va_arg(valist, uint32_t);
+        data_size = va_arg(valist, uint32_t);
+        p_read_data = va_arg(valist, void*);
+        p_data_length = va_arg(valist, size_t*);
+        return psa_its_get(uid, offset, data_size, p_read_data, p_data_length);
+    case PAL_ITS_GET_INFO:
+        uid = va_arg(valist, psa_storage_uid_t);
+        its_p_info = va_arg(valist, struct psa_storage_info_t*);
+        return psa_its_get_info(uid, its_p_info);
+    case PAL_ITS_REMOVE:
+        uid = va_arg(valist, psa_storage_uid_t);
+        return psa_its_remove(uid);
+    default:
+        return PAL_STATUS_UNSUPPORTED_FUNC;
+    }
+}

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.h
@@ -1,0 +1,31 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_INTERNAL_TRUSTED_STORAGE_INTF_H_
+#define _PAL_INTERNAL_TRUSTED_STORAGE_INTF_H_
+
+#include "pal_common.h"
+
+enum its_function_code {
+    PAL_ITS_SET                         = 0x1,
+    PAL_ITS_GET                         = 0x2,
+    PAL_ITS_GET_INFO                    = 0x3,
+    PAL_ITS_REMOVE                      = 0x4,
+};
+
+uint32_t pal_its_function(int type, va_list valist);
+#endif /* _PAL_INTERNAL_TRUSTED_STORAGE_INTF_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/protected_storage/pal_protected_storage_empty_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/protected_storage/pal_protected_storage_empty_intf.c
@@ -1,0 +1,30 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include <stdarg.h>
+#include "pal_common.h"
+
+/**
+    @brief    - This API will call the requested protected storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_ps_function(int type, va_list valist)
+{
+    return PAL_STATUS_ERROR;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/protected_storage/pal_protected_storage_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/protected_storage/pal_protected_storage_intf.c
@@ -1,0 +1,77 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+
+#include "pal_protected_storage_intf.h"
+
+/**
+    @brief    - This API will call the requested protected storage function
+    @param    - type    : function code
+                valist  : variable argument list
+    @return   - error status
+**/
+uint32_t pal_ps_function(int type, va_list valist)
+{
+    psa_storage_uid_t          uid;
+    uint32_t                   data_size, size, offset;
+    const void                 *p_write_data;
+    void                       *p_read_data;
+    size_t                     *p_data_length;
+    psa_storage_create_flags_t ps_create_flags;
+    struct psa_storage_info_t  *ps_p_info;
+
+    switch (type)
+    {
+     case PAL_PS_SET:
+         uid = va_arg(valist, psa_storage_uid_t);
+         data_size = va_arg(valist, uint32_t);
+         p_write_data = va_arg(valist, const void*);
+         ps_create_flags = va_arg(valist, psa_storage_create_flags_t);
+         return psa_ps_set(uid, data_size, p_write_data, ps_create_flags);
+     case PAL_PS_GET:
+         uid = va_arg(valist, psa_storage_uid_t);
+         offset = va_arg(valist, uint32_t);
+         data_size = va_arg(valist, uint32_t);
+         p_read_data = va_arg(valist, void*);
+         p_data_length = va_arg(valist, size_t*);
+         return psa_ps_get(uid, offset, data_size, p_read_data, p_data_length);
+     case PAL_PS_GET_INFO:
+         uid = va_arg(valist, psa_storage_uid_t);
+         ps_p_info = va_arg(valist, struct psa_storage_info_t*);
+         return psa_ps_get_info(uid, ps_p_info);
+     case PAL_PS_REMOVE:
+         uid = va_arg(valist, psa_storage_uid_t);
+         return psa_ps_remove(uid);
+     case PAL_PS_CREATE:
+         uid = va_arg(valist, psa_storage_uid_t);
+         size = va_arg(valist, uint32_t);
+         ps_create_flags = va_arg(valist, psa_storage_create_flags_t);
+         return psa_ps_create(uid, size, ps_create_flags);
+     case PAL_PS_SET_EXTENDED:
+         uid = va_arg(valist, psa_storage_uid_t);
+         offset = va_arg(valist, uint32_t);
+         data_size = va_arg(valist, uint32_t);
+         p_write_data = va_arg(valist, const void*);
+         return psa_ps_set_extended(uid, offset, data_size, p_write_data);
+     case PAL_PS_GET_SUPPORT:
+         return psa_ps_get_support();
+    default:
+        return PAL_STATUS_UNSUPPORTED_FUNC;
+    }
+
+    return PAL_STATUS_UNSUPPORTED_FUNC;
+}

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/protected_storage/pal_protected_storage_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/protected_storage/pal_protected_storage_intf.h
@@ -1,0 +1,34 @@
+/** @file
+ * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_PROTECTED_STORAGE_INTF_H_
+#define _PAL_PROTECTED_STORAGE_INTF_H_
+
+#include "pal_common.h"
+
+enum ps_function_code {
+    PAL_PS_SET                          = 0x1,
+    PAL_PS_GET                          = 0x2,
+    PAL_PS_GET_INFO                     = 0x3,
+    PAL_PS_REMOVE                       = 0x4,
+    PAL_PS_CREATE                       = 0x5,
+    PAL_PS_SET_EXTENDED                 = 0x6,
+    PAL_PS_GET_SUPPORT                  = 0x7,
+};
+
+uint32_t pal_ps_function(int type, va_list valist);
+#endif /* _PAL_PROTECTED_STORAGE_INTF_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/target.cmake
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/target.cmake
@@ -44,10 +44,14 @@ if(${SUITE} STREQUAL "CRYPTO")
 	)
 endif()
 if(${SUITE} STREQUAL "PROTECTED_STORAGE")
-	message(FATAL_ERROR "Protected Storage not supported")
+  list(APPEND PAL_SRC_C_NSPE
+    ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/protected_storage/pal_protected_storage_intf.c
+    )
 endif()
 if(${SUITE} STREQUAL "INTERNAL_TRUSTED_STORAGE")
-	message(FATAL_ERROR "Internal Trusted Storage not support")
+  list(APPEND PAL_SRC_C_NSPE
+    ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
+    )
 endif()
 if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
 	message(FATAL_ERROR "Initial attestation not supported")

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/target.cmake
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/target.cmake
@@ -44,14 +44,10 @@ if(${SUITE} STREQUAL "CRYPTO")
 	)
 endif()
 if(${SUITE} STREQUAL "PROTECTED_STORAGE")
-  list(APPEND PAL_SRC_C_NSPE
-    ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/protected_storage/pal_protected_storage_intf.c
-    )
+	message(FATAL_ERROR "Protected Storage not supported")
 endif()
 if(${SUITE} STREQUAL "INTERNAL_TRUSTED_STORAGE")
-  list(APPEND PAL_SRC_C_NSPE
-    ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
-    )
+	message(FATAL_ERROR "Internal Trusted Storage not support")
 endif()
 if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
 	message(FATAL_ERROR "Initial attestation not supported")


### PR DESCRIPTION
The following provides more information on this commit:
- Add support for ITS testing. This commits adds PAL internal trusted storage support for the
  tgt_dev_apis_stdc target non secure processing element.
- Add support for PS testing. This commit adds PAL protected storage support for the
  tgt_dev_apis_stdc target non-secure processing element.
- Fix target.cmake to enable PSA storage testing.