### PR TITLE
ITS: Fix TEST 608 Checkpoint: 17

### DIFF
--- a/api-tests/dev_apis/internal_trusted_storage/test_s008/test_its_data.h
+++ b/api-tests/dev_apis/internal_trusted_storage/test_s008/test_its_data.h
@@ -64,7 +64,7 @@ static const test_data s008_data[] = {
  0, 0 /* This is dummy for index11 */
 },
 {
- VAL_ITS_GET, PSA_ERROR_INVALID_ARGUMENT /* Call get API with offset = MAX_UINT32 */
+ VAL_ITS_GET, PSA_SUCCESS /* Call get API with offset = MAX_UINT32 */
 },
 {
  VAL_ITS_REMOVE, PSA_SUCCESS /* Remove the storage entity */


### PR DESCRIPTION
Console output (add the error code)
  TEST: 608 | DESCRIPTION: Invalid offset check
  [Info] Executing tests from non-secure
  [Check 1] Try to access data with varying valid offset
  [Check 2] Try to access data with varying invalid offset
  Failed at Checkpoint: 17
  Value: FFFFFF79  /* (FF-79+1) = -135: PSA_ERROR_INVALID_ARGUMENT */
  TEST RESULT: FAILED (Error Code=0x1)

The testing code uses TEST_ASSERT_NOT_EQUAL to compare status code.

Since the result should fail (status == PSA_ERROR_INVALID_ARGUMENT)
The fix could be:
a) Test with TEST_ASSERT_EQUAL (also need to change test_ps_data.h)
b) Set compare code to PSA_SUCCESS (so it does not match)

Seeing the test uses an out of range offset, without comparing
read buffer like Checkpoint 13 & 16 do.
Keeping the test to TEST_ASSERT_NOT_EQUAL should be the right answer.