### PR TITLE
Disable crypto SHA-1 tests for TF-M platforms

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/crypto/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/crypto/pal_crypto_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,7 +231,7 @@
 //#define ARCH_TEST_MD4
 //#define ARCH_TEST_MD5
 //#define ARCH_TEST_RIPEMD160
-#define ARCH_TEST_SHA1
+//#define ARCH_TEST_SHA1
 #define ARCH_TEST_SHA224
 #define ARCH_TEST_SHA256
 #define ARCH_TEST_SHA384

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/crypto/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/crypto/pal_crypto_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,7 +231,7 @@
 //#define ARCH_TEST_MD4
 //#define ARCH_TEST_MD5
 //#define ARCH_TEST_RIPEMD160
-#define ARCH_TEST_SHA1
+//#define ARCH_TEST_SHA1
 #define ARCH_TEST_SHA224
 #define ARCH_TEST_SHA256
 #define ARCH_TEST_SHA384

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/crypto/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/crypto/pal_crypto_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,7 +231,7 @@
 //#define ARCH_TEST_MD4
 //#define ARCH_TEST_MD5
 //#define ARCH_TEST_RIPEMD160
-#define ARCH_TEST_SHA1
+//#define ARCH_TEST_SHA1
 #define ARCH_TEST_SHA224
 #define ARCH_TEST_SHA256
 #define ARCH_TEST_SHA384

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,7 +231,7 @@
 //#define ARCH_TEST_MD4
 //#define ARCH_TEST_MD5
 //#define ARCH_TEST_RIPEMD160
-#define ARCH_TEST_SHA1
+//#define ARCH_TEST_SHA1
 #define ARCH_TEST_SHA224
 #define ARCH_TEST_SHA256
 #define ARCH_TEST_SHA384

--- a/api-tests/platform/targets/tgt_ff_tfm_an521/nspe/crypto/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_ff_tfm_an521/nspe/crypto/pal_crypto_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,7 +231,7 @@
 //#define ARCH_TEST_MD4
 //#define ARCH_TEST_MD5
 //#define ARCH_TEST_RIPEMD160
-#define ARCH_TEST_SHA1
+//#define ARCH_TEST_SHA1
 #define ARCH_TEST_SHA224
 #define ARCH_TEST_SHA256
 #define ARCH_TEST_SHA384

--- a/api-tests/platform/targets/tgt_ff_tfm_musca_a/nspe/crypto/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_ff_tfm_musca_a/nspe/crypto/pal_crypto_config.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -231,7 +231,7 @@
 //#define ARCH_TEST_MD4
 //#define ARCH_TEST_MD5
 //#define ARCH_TEST_RIPEMD160
-#define ARCH_TEST_SHA1
+//#define ARCH_TEST_SHA1
 #define ARCH_TEST_SHA224
 #define ARCH_TEST_SHA256
 #define ARCH_TEST_SHA384


### PR DESCRIPTION
Disables the configuration option for crypto SHA-1 tests for all TF-M platforms, as TF-M plans to drop support for SHA-1 in the Crypto service.