### PR TITLE
Crypto persistent key test fixes for TF-M

### DIFF
--- a/api-tests/dev_apis/crypto/test_c050/test_c050.c
+++ b/api-tests/dev_apis/crypto/test_c050/test_c050.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -189,10 +189,11 @@ int32_t psa_open_key_test(caller_security_t caller)
             val->crypto_function(VAL_CRYPTO_GET_KEY_BITS, &get_attributes, &get_key_bits);
             TEST_ASSERT_EQUAL(get_key_bits, check1[i].expected_bit_length, TEST_CHECKPOINT_NUM(18));
 
-            val->crypto_function(VAL_CRYPTO_GET_KEY_USAGE_FLAGS, &attributes, &get_key_usage_flags);
+            val->crypto_function(VAL_CRYPTO_GET_KEY_USAGE_FLAGS, &get_attributes,
+                                 &get_key_usage_flags);
             TEST_ASSERT_EQUAL(get_key_usage_flags, check1[i].usage, TEST_CHECKPOINT_NUM(19));
 
-            val->crypto_function(VAL_CRYPTO_GET_KEY_ALGORITHM, &attributes, &get_key_algorithm);
+            val->crypto_function(VAL_CRYPTO_GET_KEY_ALGORITHM, &get_attributes, &get_key_algorithm);
             TEST_ASSERT_EQUAL(get_key_algorithm, check1[i].key_alg, TEST_CHECKPOINT_NUM(20));
 
             /* Export a key in binary format */
@@ -220,13 +221,17 @@ int32_t psa_open_key_test(caller_security_t caller)
             /* Reset the key attributes */
             val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
 
+            /* Destroy the persistent key to clean up storage for the next test */
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key_handle);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(25));
+
             /* Save the check ID and set boot flags */
              ++i;
             status = val->nvmem_write(VAL_NVMEM_OFFSET(NV_TEST_DATA1), &i, sizeof(int32_t));
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(25));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(26));
 
             status = val->set_boot_flag(BOOT_NOT_EXPECTED);
-            TEST_ASSERT_EQUAL(status, VAL_STATUS_SUCCESS, TEST_CHECKPOINT_NUM(26));
+            TEST_ASSERT_EQUAL(status, VAL_STATUS_SUCCESS, TEST_CHECKPOINT_NUM(27));
 
         }
         else

--- a/api-tests/dev_apis/crypto/test_c050/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c050/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -243,8 +243,8 @@ static test_data check1[] = {
 
 #ifdef ARCH_TEST_ECDSA
 #ifdef ARCH_TEST_ECC_CURVE_SECP256R1
-{"Test psa_open_key with EC Public key\n", 9, 0x789,
- PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP256R1),
+{"Test psa_open_key with EC Public key\n", 9,
+ PSA_KEY_TYPE_ECC_PUBLIC_KEY(PSA_ECC_CURVE_SECP256R1), 0x789,
  {0},
  65, 0, PSA_KEY_USAGE_EXPORT, PSA_ALG_ECDSA_ANY, PSA_KEY_LIFETIME_PERSISTENT,
  256, 65, PSA_SUCCESS
@@ -252,8 +252,8 @@ static test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_ECC_CURVE_SECP224R1
-{"Test psa_open_key with EC keypair\n", 10, 0x1234,
- PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP224R1),
+{"Test psa_open_key with EC keypair\n", 10,
+ PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_CURVE_SECP224R1), 0x1234,
  {0},
  28, 0, PSA_KEY_USAGE_EXPORT, PSA_ALG_ECDSA_ANY, PSA_KEY_LIFETIME_PERSISTENT,
  224, 28, PSA_SUCCESS
@@ -263,13 +263,13 @@ static test_data check1[] = {
 
 #ifdef ARCH_TEST_CIPER_MODE_CTR
 #ifdef ARCH_TEST_AES
-{"Test psa_open_key with key data greater than the algorithm size\n", 11, PSA_KEY_TYPE_AES,
+{"Test psa_open_key with volatile key\n", 11, PSA_KEY_TYPE_AES,
  0x5678,
 {0x24, 0x13, 0x61, 0x47, 0x61, 0xB8, 0xC8, 0xF0, 0xDF, 0xAB, 0x5A, 0x0E, 0x87,
  0x40, 0xAC, 0xA3, 0x90, 0x77, 0x83, 0x52, 0x31, 0x74, 0xF9, 0x05, 0xC9, 0xED,
  0xDF, 0x25, 0x17, 0x68, 0x86, 0xAE},
  AES_32B_KEY_SIZE, 0, PSA_KEY_USAGE_EXPORT, PSA_ALG_CTR, PSA_KEY_LIFETIME_VOLATILE,
- BYTES_TO_BITS(AES_32B_KEY_SIZE), AES_32B_KEY_SIZE, PSA_ERROR_INVALID_ARGUMENT
+ BYTES_TO_BITS(AES_32B_KEY_SIZE), AES_32B_KEY_SIZE, PSA_ERROR_DOES_NOT_EXIST
 },
 #endif
 #endif

--- a/api-tests/dev_apis/crypto/test_c051/test_c051.c
+++ b/api-tests/dev_apis/crypto/test_c051/test_c051.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -145,30 +145,38 @@ int32_t psa_close_key_test(caller_security_t caller)
                      &check1[i].key_handle);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(13));
 
+            /* Get the attributes of the persistent key and check if it matches the given value */
+            status = val->crypto_function(VAL_CRYPTO_GET_KEY_ATTRIBUTES, check1[i].key_handle,
+                     &attributes);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(14));
+
             val->crypto_function(VAL_CRYPTO_GET_KEY_TYPE, &attributes, &get_key_type);
-            TEST_ASSERT_EQUAL(get_key_type, check1[i].key_type, TEST_CHECKPOINT_NUM(14));
+            TEST_ASSERT_EQUAL(get_key_type, check1[i].key_type, TEST_CHECKPOINT_NUM(15));
 
             val->crypto_function(VAL_CRYPTO_GET_KEY_ID, &attributes, &get_key_id);
-            TEST_ASSERT_EQUAL(get_key_id, check1[i].key_id, TEST_CHECKPOINT_NUM(15));
+            TEST_ASSERT_EQUAL(get_key_id, check1[i].key_id, TEST_CHECKPOINT_NUM(16));
 
             val->crypto_function(VAL_CRYPTO_GET_KEY_LIFETIME, &attributes, &get_key_lifetime);
-            TEST_ASSERT_EQUAL(get_key_lifetime, check1[i].key_lifetime, TEST_CHECKPOINT_NUM(16));
+            TEST_ASSERT_EQUAL(get_key_lifetime, check1[i].key_lifetime, TEST_CHECKPOINT_NUM(17));
 
             val->crypto_function(VAL_CRYPTO_GET_KEY_USAGE_FLAGS, &attributes, &get_key_usage_flags);
-            TEST_ASSERT_EQUAL(get_key_usage_flags, check1[i].usage, TEST_CHECKPOINT_NUM(17));
+            TEST_ASSERT_EQUAL(get_key_usage_flags, check1[i].usage, TEST_CHECKPOINT_NUM(18));
 
             val->crypto_function(VAL_CRYPTO_GET_KEY_ALGORITHM, &attributes, &get_key_algorithm);
-            TEST_ASSERT_EQUAL(get_key_algorithm, check1[i].key_alg, TEST_CHECKPOINT_NUM(18));
+            TEST_ASSERT_EQUAL(get_key_algorithm, check1[i].key_alg, TEST_CHECKPOINT_NUM(19));
 
             val->crypto_function(VAL_CRYPTO_GET_KEY_BITS, &attributes, &get_key_bits);
             TEST_ASSERT_EQUAL(get_key_bits,  check1[i].expected_bit_length,
-            TEST_CHECKPOINT_NUM(19));
+            TEST_CHECKPOINT_NUM(20));
+
+            /* Reset the key attributes */
+            val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
 
             status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, check1[i].key_handle);
-            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(20));
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(21));
 
             status = val->crypto_function(VAL_CRYPTO_CLOSE_KEY, check1[i].key_handle);
-            TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(21));
+            TEST_ASSERT_EQUAL(status, PSA_ERROR_INVALID_HANDLE, TEST_CHECKPOINT_NUM(22));
         }
 
     }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/crypto/pal_crypto_intf.c
@@ -511,6 +511,8 @@ int32_t pal_crypto_function(int type, va_list valist)
             for (i = 0; i < PAL_KEY_SLOT_COUNT; i++)
                 psa_destroy_key(i);
             return 0;
+        case PAL_CRYPTO_RESET:
+            return PAL_STATUS_UNSUPPORTED_FUNC;
         default:
             return PAL_STATUS_UNSUPPORTED_FUNC;
     }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/crypto/pal_crypto_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/crypto/pal_crypto_intf.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,7 @@ enum crypto_function_code {
     PAL_CRYPTO_AEAD_FINISH                      = 0x4A,
     PAL_CRYPTO_AEAD_VERIFY                      = 0x4B,
     PAL_CRYPTO_AEAD_ABORT                       = 0x4C,
+    PAL_CRYPTO_RESET                            = 0xFD,
     PAL_CRYPTO_FREE                             = 0xFE,
 };
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/crypto/pal_crypto_intf.c
@@ -20,6 +20,8 @@
 
 #define  PAL_KEY_SLOT_COUNT  32
 
+int32_t tfm_platform_system_reset(void);
+
 /**
     @brief    - This API will call the requested crypto function
     @param    - type    : function code
@@ -511,6 +513,8 @@ int32_t pal_crypto_function(int type, va_list valist)
             for (i = 0; i < PAL_KEY_SLOT_COUNT; i++)
                 psa_destroy_key(i);
             return 0;
+        case PAL_CRYPTO_RESET:
+            return tfm_platform_system_reset();
         default:
             return PAL_STATUS_UNSUPPORTED_FUNC;
     }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/crypto/pal_crypto_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/crypto/pal_crypto_intf.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,7 @@ enum crypto_function_code {
     PAL_CRYPTO_AEAD_FINISH                      = 0x4A,
     PAL_CRYPTO_AEAD_VERIFY                      = 0x4B,
     PAL_CRYPTO_AEAD_ABORT                       = 0x4C,
+    PAL_CRYPTO_RESET                            = 0xFD,
     PAL_CRYPTO_FREE                             = 0xFE,
 };
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/crypto/pal_crypto_intf.c
@@ -20,6 +20,8 @@
 
 #define  PAL_KEY_SLOT_COUNT  32
 
+int32_t tfm_platform_system_reset(void);
+
 /**
     @brief    - This API will call the requested crypto function
     @param    - type    : function code
@@ -511,6 +513,8 @@ int32_t pal_crypto_function(int type, va_list valist)
             for (i = 0; i < PAL_KEY_SLOT_COUNT; i++)
                 psa_destroy_key(i);
             return 0;
+        case PAL_CRYPTO_RESET:
+            return tfm_platform_system_reset();
         default:
             return PAL_STATUS_UNSUPPORTED_FUNC;
     }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/crypto/pal_crypto_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/crypto/pal_crypto_intf.h
@@ -96,6 +96,7 @@ enum crypto_function_code {
     PAL_CRYPTO_AEAD_FINISH                      = 0x4A,
     PAL_CRYPTO_AEAD_VERIFY                      = 0x4B,
     PAL_CRYPTO_AEAD_ABORT                       = 0x4C,
+    PAL_CRYPTO_RESET                            = 0xFD,
     PAL_CRYPTO_FREE                             = 0xFE,
 };
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/crypto/pal_crypto_intf.c
@@ -20,6 +20,8 @@
 
 #define  PAL_KEY_SLOT_COUNT  32
 
+int32_t tfm_platform_system_reset(void);
+
 /**
     @brief    - This API will call the requested crypto function
     @param    - type    : function code
@@ -511,6 +513,8 @@ int32_t pal_crypto_function(int type, va_list valist)
             for (i = 0; i < PAL_KEY_SLOT_COUNT; i++)
                 psa_destroy_key(i);
             return 0;
+        case PAL_CRYPTO_RESET:
+            return tfm_platform_system_reset();
         default:
             return PAL_STATUS_UNSUPPORTED_FUNC;
     }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/crypto/pal_crypto_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/crypto/pal_crypto_intf.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,7 @@ enum crypto_function_code {
     PAL_CRYPTO_AEAD_FINISH                      = 0x4A,
     PAL_CRYPTO_AEAD_VERIFY                      = 0x4B,
     PAL_CRYPTO_AEAD_ABORT                       = 0x4C,
+    PAL_CRYPTO_RESET                            = 0xFD,
     PAL_CRYPTO_FREE                             = 0xFE,
 };
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.c
@@ -20,6 +20,8 @@
 
 #define  PAL_KEY_SLOT_COUNT  32
 
+int32_t tfm_platform_system_reset(void);
+
 /**
     @brief    - This API will call the requested crypto function
     @param    - type    : function code
@@ -511,6 +513,8 @@ int32_t pal_crypto_function(int type, va_list valist)
             for (i = 0; i < PAL_KEY_SLOT_COUNT; i++)
                 psa_destroy_key(i);
             return 0;
+        case PAL_CRYPTO_RESET:
+            return tfm_platform_system_reset();
         default:
             return PAL_STATUS_UNSUPPORTED_FUNC;
     }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/crypto/pal_crypto_intf.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -96,6 +96,7 @@ enum crypto_function_code {
     PAL_CRYPTO_AEAD_FINISH                      = 0x4A,
     PAL_CRYPTO_AEAD_VERIFY                      = 0x4B,
     PAL_CRYPTO_AEAD_ABORT                       = 0x4C,
+    PAL_CRYPTO_RESET                            = 0xFD,
     PAL_CRYPTO_FREE                             = 0xFE,
 };
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/crypto/pal_crypto_intf.c
@@ -20,6 +20,8 @@
 
 #define  PAL_KEY_SLOT_COUNT  32
 
+int32_t tfm_platform_system_reset(void);
+
 /**
     @brief    - This API will call the requested crypto function
     @param    - type    : function code
@@ -511,6 +513,8 @@ int32_t pal_crypto_function(int type, va_list valist)
             for (i = 0; i < PAL_KEY_SLOT_COUNT; i++)
                 psa_destroy_key(i);
             return 0;
+        case PAL_CRYPTO_RESET:
+            return tfm_platform_system_reset();
         default:
             return PAL_STATUS_UNSUPPORTED_FUNC;
     }

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/crypto/pal_crypto_intf.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/crypto/pal_crypto_intf.h
@@ -96,6 +96,7 @@ enum crypto_function_code {
     PAL_CRYPTO_AEAD_FINISH                      = 0x4A,
     PAL_CRYPTO_AEAD_VERIFY                      = 0x4B,
     PAL_CRYPTO_AEAD_ABORT                       = 0x4C,
+    PAL_CRYPTO_RESET                            = 0xFD,
     PAL_CRYPTO_FREE                             = 0xFE,
 };
 


### PR DESCRIPTION
Couple of patches:

1. Adds support for CRYPTO_RESET function on TF-M platforms

2. Makes some fixes to persistent key tests, found when testing against TF-M

Fixes #161 