### PR TITLE
Issue-175 : Invalid Buffer Index in Crypto 21

### DIFF
--- a/api-tests/dev_apis/crypto/test_c021/test_c021.c
+++ b/api-tests/dev_apis/crypto/test_c021/test_c021.c
@@ -21,8 +21,8 @@
 #include "test_data.h"
 #include "val_crypto.h"
 
-#define     SLOT_1      1
-#define     SLOT_2      2
+#define     SLOT_1      0
+#define     SLOT_2      1
 
 client_test_t test_c021_crypto_list[] = {
     NULL,


### PR DESCRIPTION
We use SLOT_1 and SLOT_2 values as index in key_handle array but SLOT_2 (2) overflows the key handle array
`psa_key_handle_t                key_handle[2];`
