### PR TITLE
Issue-179 : size_t type byte arrays

### DIFF
--- a/api-tests/dev_apis/crypto/test_c058/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c058/test_data.h
@@ -34,7 +34,7 @@ typedef struct {
     size_t                  plaintext_length;
     size_t                  input_length;
     size_t                  output_size;
-    size_t                  expected_output[45];
+    uint8_t                 expected_output[45];
     size_t                  expected_length;
     psa_status_t            expected_status;
 } test_data;

--- a/api-tests/dev_apis/crypto/test_c059/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c059/test_data.h
@@ -34,10 +34,10 @@ typedef struct {
     size_t                  plaintext_length;
     size_t                  input_length;
     size_t                  output_size;
-    size_t                  expected_output[45];
+    uint8_t                 expected_output[45];
     size_t                  expected_length;
     size_t                  tag_size;
-    size_t                  expected_tag[64];
+    uint8_t                 expected_tag[64];
     size_t                  expected_tag_length;
     psa_status_t            expected_status;
 } test_data;

--- a/api-tests/dev_apis/crypto/test_c061/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c061/test_data.h
@@ -34,10 +34,10 @@ typedef struct {
     size_t                  plaintext_length;
     size_t                  input_length;
     size_t                  output_size;
-    size_t                  expected_output[45];
+    uint8_t                 expected_output[45];
     size_t                  expected_length;
     size_t                  tag_size;
-    size_t                  expected_tag[64];
+    uint8_t                 expected_tag[64];
     size_t                  expected_tag_length;
     psa_status_t            expected_status;
 } test_data;


### PR DESCRIPTION
We assume the array types should be uint8_t, not size_t. 