### PR TITLE
PSoC6: NVMEM: use address defined in target.cfg

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_driver_intf.c
@@ -75,8 +75,6 @@ int pal_wd_timer_disable_ns(addr_t base_addr)
     return PAL_STATUS_SUCCESS;
 }
 
-static char nvmem[1024];
-
 /**
     @brief    - Reads from given non-volatile address.
     @param    - base    : Base address of nvmem
@@ -87,7 +85,7 @@ static char nvmem[1024];
 **/
 int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size)
 {
-    memcpy(buffer, &nvmem[offset], size);
+    memcpy(buffer, (void *)(base+offset), size);
     return PAL_STATUS_SUCCESS;
 }
 
@@ -101,7 +99,7 @@ int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size)
 **/
 int pal_nvmem_write_ns(addr_t base, uint32_t offset, void *buffer, int size)
 {
-    memcpy(&nvmem[offset], buffer, size);
+    memcpy((void *)(base+offset), buffer, size);
     return PAL_STATUS_SUCCESS;
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/target.cfg
@@ -36,6 +36,6 @@ watchdog.0.timeout_in_micro_sec_crypto = 0x1312D00; //18.0 sec : 18 * 1000 * 100
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;
-nvmem.0.start = 0x28100000;
-nvmem.0.end = 0x281003FF;
+nvmem.0.start = 0x080e6c00;
+nvmem.0.end = 0x080e6fff;
 nvmem.0.permission = TYPE_READ_WRITE;


### PR DESCRIPTION
---- Problem ----
The local 'nvmem' buffer is in BSS section which would be
zeroed out during reset.

---- Solution ----
Reserve a 4KB memory in TF-M when it compiles with PSA test.

---- Note ----
This patch depends on the patch in TF-M to reserve the
4KB memory @ 0x080e6c00
  Platform: PSoC6: reserve PSA NVMEM (if PSA_API_TEST_NS)

Signed-off-by: Alamy Liu <alamy.liu@infineon.com>