### PR TITLE
Fix	: Remove the requirement of 32-bit host compiler dependency.

### DIFF
--- a/api-tests/docs/sw_requirements.md
+++ b/api-tests/docs/sw_requirements.md
@@ -5,7 +5,7 @@ Current release has been tested againt the below tools versions: <br />
 
 - Host Operating System     : Ubuntu 16.04, Windows 10
 - Scripting tools           : Python 3.7.1
-- Host Compiler toolchain   : GCC 5.4.0 32-Bit (Linux Host) or MinGW 6.3.0 32-Bit (Windows Host)
+- Host Compiler toolchain   : GCC 5.4.0 (Linux Host) or MinGW 6.3.0 (Windows Host)
 - Cross Compiler toolchain  : GNU Arm Embedded Toolchain 6.3.1, 7.3.1 or Arm Compiler 6.11
 - Build tools               : CMake 3.10
 

--- a/api-tests/tools/scripts/target_cfg/CMakeLists.txt
+++ b/api-tests/tools/scripts/target_cfg/CMakeLists.txt
@@ -63,8 +63,6 @@ add_executable(${PROJECT_NAME} ${TGT_CONFIG_SOURCE_C})
 foreach(include_path ${TARGET_HEADER_GEN_INCLUDE_PATHS})
 	target_include_directories(${PROJECT_NAME} PRIVATE ${include_path})
 endforeach()
-set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-m32 -w")
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-m32")
 
 # Adding target to tell we want OUTPUT_HEADER
 add_custom_target(


### PR DESCRIPTION
Detail	: The existing build flow for psa-arch-tests require a need
	  to have 32-bit host compiler for its infrastructure need.

	  The changes will not have such a requirement. So effectively
	  psa-arch-tests can be build on 32/64 bit hosts.