### PR TITLE
Remove an unnecessary check from initial attestation test suite

### DIFF
--- a/api-tests/platform/targets/common/nspe/initial_attestation/pal_attestation_crypto.c
+++ b/api-tests/platform/targets/common/nspe/initial_attestation/pal_attestation_crypto.c
@@ -231,9 +231,6 @@ static uint32_t pal_import_attest_key(psa_algorithm_t key_alg)
         if (status != PSA_SUCCESS)
             return PAL_ATTEST_ERR_KEY_FAIL;
 
-        if (ecc_curve == USHRT_MAX)
-            return PAL_ATTEST_ERROR;
-
         /* Set key type for public key */
         attest_key_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY(ecc_curve);
 
@@ -271,9 +268,6 @@ static uint32_t pal_import_attest_key(psa_algorithm_t key_alg)
                                            &ecc_curve);
         if (status != PSA_SUCCESS)
             return PAL_ATTEST_ERR_KEY_FAIL;
-
-        if (ecc_curve == USHRT_MAX)
-            return PAL_ATTEST_ERROR;
 
         /* Set key type for public key */
         attest_key_type = PSA_KEY_TYPE_ECC_PUBLIC_KEY(ecc_curve);


### PR DESCRIPTION
This patch removes a seemingly unncessary check from the initial
attestation test suite and it also resolves the issue #231.

Signed-off-by: Soby Mathew <soby.mathew@arm.com>