### PR TITLE
Alter asm to __asm to comply with C99

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_driver_intf.c
@@ -128,7 +128,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while (1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_driver_intf.c
@@ -130,7 +130,7 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_driver_intf.c
@@ -137,7 +137,7 @@ void pal_terminate_simulation(void)
 
     while (1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }
 

--- a/api-tests/platform/targets/tgt_ff_tfm_an521/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_an521/nspe/pal_driver_ipc_intf.c
@@ -275,6 +275,6 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/api-tests/platform/targets/tgt_ff_tfm_musca_a/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_musca_a/nspe/pal_driver_ipc_intf.c
@@ -275,6 +275,6 @@ void pal_terminate_simulation(void)
 
     while(1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/api-tests/platform/targets/tgt_ff_tfm_musca_b1/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_musca_b1/nspe/pal_driver_ipc_intf.c
@@ -275,6 +275,6 @@ void pal_terminate_simulation(void)
 
     while (1)
     {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/tbsa-v8m/tbsa_app/tbsa_main.c
+++ b/tbsa-v8m/tbsa_app/tbsa_main.c
@@ -71,6 +71,6 @@ void tbsa_main (void)
 
 exit:
     while(1) {
-        asm volatile("WFI");
+        __asm volatile("WFI");
     }
 }

--- a/tbsa-v8m/test_pool/base/test_b001/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b001/secure.c
@@ -55,16 +55,16 @@ void hard_fault_esr(unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 tbsa_status_t setup_ns_env(void)

--- a/tbsa-v8m/test_pool/base/test_b005/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b005/secure.c
@@ -41,16 +41,16 @@ void hard_fault_esr (unsigned long *sf_args)
 
 __attribute__((naked)) void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/base/test_b006/secure.c
+++ b/tbsa-v8m/test_pool/base/test_b006/secure.c
@@ -41,16 +41,16 @@ void hard_fault_esr (unsigned long *sf_args)
 
 __attribute__((naked)) void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/crypto/test_c003/non_secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c003/non_secure.c
@@ -99,8 +99,8 @@ void test_payload(tbsa_val_api_t *val)
 
         /* Shouldn't come here */
         val->print(PRINT_ERROR, "\n\r\tFault didn't occur when HUK accessed from Non-secure world!", 0);
-        asm volatile ("DSB");
-        asm volatile ("ISB");
+        __asm volatile ("DSB");
+        __asm volatile ("ISB");
         val->system_reset(WARM_RESET);
     }
 }

--- a/tbsa-v8m/test_pool/crypto/test_c003/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c003/secure.c
@@ -48,8 +48,8 @@ void hard_fault_esr (unsigned long *sf_args)
     g_val->print(PRINT_DEBUG, "\n\r\tHardFault triggered when HUK was accessed from"
                  "non-Trusted world", 0);
 
-    asm volatile("DSB");
-    asm volatile("ISB");
+    __asm volatile("DSB");
+    __asm volatile("ISB");
 
     g_val->system_reset(WARM_RESET);
 
@@ -59,16 +59,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void test_payload(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/crypto/test_c006/non_secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c006/non_secure.c
@@ -150,8 +150,8 @@ void test_payload(tbsa_val_api_t *val)
 
     /* Control shouldn't come here */
     val->print(PRINT_ERROR, "\n\r\tFault didn't occur when Trusted HW Key accessed from Non-secure world!", 0);
-    asm volatile ("DSB");
-    asm volatile ("ISB");
+    __asm volatile ("DSB");
+    __asm volatile ("ISB");
     val->system_reset(WARM_RESET);
 }
 

--- a/tbsa-v8m/test_pool/crypto/test_c006/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c006/secure.c
@@ -45,16 +45,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/crypto/test_c011/secure.c
+++ b/tbsa-v8m/test_pool/crypto/test_c011/secure.c
@@ -130,9 +130,9 @@ void test_payload(tbsa_val_api_t *val)
         }
 
         /* Change the mode to unprivilege access */
-        asm volatile ("MRS %0, control" : "=r" (control));
+        __asm volatile ("MRS %0, control" : "=r" (control));
         control |= 0x1;
-        asm volatile ("MSR control, %0" : : "r" (control) : "memory");
+        __asm volatile ("MSR control, %0" : : "r" (control) : "memory");
 
         /* Performing unprivilege access to Confidential fuse */
         status = val->fuse_ops(FUSE_READ, fuse_desc->addr, data1, MIN(FUSE_SIZE, fuse_desc->size));

--- a/tbsa-v8m/test_pool/debug/test_d003/secure.c
+++ b/tbsa-v8m/test_pool/debug/test_d003/secure.c
@@ -39,7 +39,7 @@ void delay (uint32_t delay_cnt)
 {
     while(delay_cnt--)
     {
-        asm volatile("NOP");
+        __asm volatile("NOP");
     }
 }
 
@@ -196,8 +196,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_9, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
 
                     /* Indicate the debugger about the transition to CLOSED state */
                     if (test_dbg_seq_write((uint32_t)(memory_desc->start), SEQ_CLOSED_STATE_READ)) {
@@ -226,8 +226,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_B, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
 
                     /*Initialize the memory with known data*/
                     val->mem_write((uint32_t *)memory_desc->start, WORD, ~TEST_DATA);
@@ -245,8 +245,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_C, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
 
                     /* Indicate the debugger about the transition to CLOSED state */
                     if (test_dbg_seq_write((uint32_t)(memory_desc->start), SEQ_CLOSED_STATE_WRITE)) {
@@ -272,8 +272,8 @@ void test_payload(tbsa_val_api_t *val)
                     if (val->err_check_set(TEST_CHECKPOINT_E, status)) {
                         goto clean_up;
                     }
-                    asm volatile("DSB");
-                    asm volatile("ISB");
+                    __asm volatile("DSB");
+                    __asm volatile("ISB");
                 }
                 instance++;
             } while (instance < GET_NUM_INSTANCE(memory_desc));

--- a/tbsa-v8m/test_pool/debug/test_d008/secure.c
+++ b/tbsa-v8m/test_pool/debug/test_d008/secure.c
@@ -129,9 +129,9 @@ void test_payload(tbsa_val_api_t *val)
                  }
 
                  /* Change the mode to unprivilege access */
-                 asm volatile ("MRS %0, control" : "=r" (control));
+                 __asm volatile ("MRS %0, control" : "=r" (control));
                  control |= 0x1;
-                 asm volatile ("MSR control, %0" : : "r" (control) : "memory");
+                 __asm volatile ("MSR control, %0" : : "r" (control) : "memory");
 
                  /* Performing unprivilege access to DPM */
                  certificate_valid[dpm_instance] = val->crypto_validate_certificate(dpm_desc->certificate_addr, dpm_desc->public_key_addr, dpm_desc->certificate_size,dpm_desc->public_key_size);

--- a/tbsa-v8m/test_pool/mem/test_m001/secure.c
+++ b/tbsa-v8m/test_pool/mem/test_m001/secure.c
@@ -46,16 +46,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 tbsa_status_t setup_ns_env(void)

--- a/tbsa-v8m/test_pool/peripherals/test_p001/secure.c
+++ b/tbsa-v8m/test_pool/peripherals/test_p001/secure.c
@@ -42,16 +42,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/timer/test_t001/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t001/secure.c
@@ -58,16 +58,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/timer/test_t002/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t002/secure.c
@@ -52,16 +52,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/timer/test_t003/secure.c
+++ b/tbsa-v8m/test_pool/timer/test_t003/secure.c
@@ -43,16 +43,16 @@ void hard_fault_esr (unsigned long *sf_args)
 
 __attribute__((naked)) void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
+++ b/tbsa-v8m/test_pool/version_counters/test_v001/secure.c
@@ -41,16 +41,16 @@ void hard_fault_esr (unsigned long *sf_args)
 __attribute__((naked))
 void HF_Handler(void)
 {
-    asm volatile("mrs r0, control_ns \n"
-                 "mov r1, #0x2       \n"
-                 "and r0, r1         \n"
-                 "cmp r0, r1         \n"
-                 "beq _psp_ns        \n"
-                 "mrs r0, msp_ns     \n"
-                 "b hard_fault_esr \n"
-                 "_psp_ns:           \n"
-                 "mrs r0, psp_ns     \n"
-                 "b hard_fault_esr \n");
+    __asm volatile("mrs r0, control_ns \n"
+                   "mov r1, #0x2       \n"
+                   "and r0, r1         \n"
+                   "cmp r0, r1         \n"
+                   "beq _psp_ns        \n"
+                   "mrs r0, msp_ns     \n"
+                   "b hard_fault_esr \n"
+                   "_psp_ns:           \n"
+                   "mrs r0, psp_ns     \n"
+                   "b hard_fault_esr \n");
 }
 
 void entry_hook(tbsa_val_api_t *val)

--- a/tbsa-v8m/val/src/val_debug.c
+++ b/tbsa-v8m/val/src/val_debug.c
@@ -118,16 +118,16 @@ tbsa_status_t val_debug_set_status(dbg_access_t dbg_access, dbg_seq_status_t dbg
                 return TBSA_STATUS_TIMEOUT;
             }
             *(uint32_t *)dpm_desc->flag_addr = dbg_status;
-            asm volatile("DSB");
-            asm volatile("ISB");
+            __asm volatile("DSB");
+            __asm volatile("ISB");
             break;
         case DBG_WRITE:
             *(uint32_t *)dpm_desc->flag_addr = dbg_status | DBG_FLAG_TXFULL;
             break;
         case DBG_READ:
             *(uint32_t *)dpm_desc->flag_addr &= ~DBG_FLAG_RXFULL;
-            asm volatile("DSB");
-            asm volatile("ISB");
+            __asm volatile("DSB");
+            __asm volatile("ISB");
             break;
         default:
             return TBSA_STATUS_INCORRECT_VALUE;

--- a/tbsa-v8m/val/src/val_ns_callable.c
+++ b/tbsa-v8m/val/src/val_ns_callable.c
@@ -22,7 +22,7 @@
 #define TRANSITION_NS_TO_S(fn_ret, fn_name, ...) \
     __attribute__((section(".tbsa_nsc_entry_points"), naked)) \
     fn_ret fn_name ## _nsc(__VA_ARGS__) { \
-        asm volatile( \
+        __asm volatile( \
             "sg                   \n" \
             "push {r7}            \n" \
             "push {lr}            \n" \


### PR DESCRIPTION
C99 spec does now allow asm as a keyword, so compilers instead use __asm.
This allows the tests to be build by external projects that specify
--std=C99

Signed-off-by: Raef Coles <raef.coles@arm.com>