### PR TITLE
Add ARCH_TEST_RSA_2048_GEN_KEY

### DIFF
--- a/api-tests/dev_apis/crypto/test_c016/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c016/test_data.h
@@ -105,6 +105,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_RSA
 #ifdef ARCH_TEST_RSA_2048
+#ifdef ARCH_TEST_RSA_2048_GEN_KEY
 #ifdef ARCH_TEST_RSA_PKCS1V15_SIGN_RAW
 {
     .test_desc       = "Test psa_generate_key with RSA 2048 Keypair\n",
@@ -115,6 +116,7 @@ static const test_data check1[] = {
     .expected_range  = {1190, 1194},
     .expected_status = PSA_SUCCESS
 },
+#endif
 #endif
 #endif
 #endif

--- a/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_stdc/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an524/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an539/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_a/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_psoc64/nspe/pal_crypto_config.h
@@ -37,6 +37,7 @@
 #define ARCH_TEST_RSA
 #define ARCH_TEST_RSA_1024
 #define ARCH_TEST_RSA_2048
+//#define ARCH_TEST_RSA_2048_GEN_KEY
 #define ARCH_TEST_RSA_3072
 
 /**


### PR DESCRIPTION
PSoC64 needs a way to disable RSA2048 key generation since it
is an unbounded operation and may take an extremely long time
to complete.

Signed-off-by: Raymond Ngun <raymond.ngun@infineon.com>