### PR TITLE
Add missing initializtion to crypto test c019

### DIFF
--- a/api-tests/dev_apis/crypto/test_c019/test_c019.c
+++ b/api-tests/dev_apis/crypto/test_c019/test_c019.c
@@ -104,7 +104,7 @@ int32_t psa_key_derivation_key_agreement_test(caller_security_t caller __UNUSED)
 int32_t psa_key_derivation_key_agreement_negative_test(caller_security_t caller __UNUSED)
 {
     int32_t                         status;
-    psa_key_derivation_operation_t  operation;
+    psa_key_derivation_operation_t  operation = PSA_KEY_DERIVATION_OPERATION_INIT;
     psa_key_handle_t                key_handle = 8;
 
     if (valid_test_input_index < 0)


### PR DESCRIPTION
psa_key_derivation_operation_t is not properly initialized.

Change-Id: Id31216d6ccc60af44074c4dbfec257ee6df8caa5
Signed-off-by: Raymond Ngun <raymond.ngun@infineon.com>