### PR TITLE
api-tests: fix CMakeLists include on non-Linux

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -28,8 +28,7 @@ find_package(Git REQUIRED)
 
 get_filename_component(PSA_ROOT_DIR . ABSOLUTE)
 
-list(APPEND CMAKE_MODULE_PATH ${PSA_ROOT_DIR}/tools/cmake)
-include("common/Utils")
+include(${PSA_ROOT_DIR}/tools/cmake/common/Utils.cmake)
 include(${PSA_ROOT_DIR}/tools/cmake/common/CMakeSettings.cmake)
 include(${PSA_ROOT_DIR}/tools/cmake/common/CMakeExternal.cmake)
 


### PR DESCRIPTION
Fixes: #246

Credits to @ccli8(ccli8@nuvoton.com) for finding the fix.

When we use CMake's `CMAKE_MODULE_PATH` feature, the module name being included should not contain slashes (`/`) which can't be resolved (from regular file names) by CMake on Windows and macOS hosts, resulting in failure of `include("common/Utils")` on those systems.

Since other modules are included with full paths which work in all cases, do the same for `common/Utils.cmake`.

@jk-arm Please review, thanks.