### PR TITLE
nrf: Increase all watchdog timeouts to 60 seconds

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf/target.cfg
@@ -23,12 +23,12 @@ uart.0.base = 0; // Unused value
 watchdog.num = 1;
 watchdog.0.base = 0; // Unused value
 watchdog.0.num_of_tick_per_micro_sec = 1;
-watchdog.0.timeout_in_micro_sec_low = 0xF4240;      //1.0  sec :  1 * 1000 * 1000
-watchdog.0.timeout_in_micro_sec_medium = 0x1E8480;  //2.0  sec :  2 * 1000 * 1000
-watchdog.0.timeout_in_micro_sec_high = 0x4C4B40;    //5.0  sec :  5 * 1000 * 1000
-watchdog.0.timeout_in_micro_sec_crypto = 0x1312D00; //18.0 sec : 18 * 1000 * 1000
+watchdog.0.timeout_in_micro_sec_low = 60000000; //60 secs
+watchdog.0.timeout_in_micro_sec_medium = 60000000; //60 secs
+watchdog.0.timeout_in_micro_sec_high = 60000000; //60 secs
+watchdog.0.timeout_in_micro_sec_crypto = 60000000; //60 secs
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
-nvmem.num =1;
+nvmem.num = 1;
 nvmem.0.start = 0; // Unused value;
 nvmem.0.end = 0x3ff;


### PR DESCRIPTION
To not interfere with the tests.
These are rarely triggered, so the long timeout is not an issue.
Also fix a whitespace issue

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>