### PR TITLE
Remove 32-bit host compiler dependencies

### DIFF
--- a/api-tests/tools/scripts/target_cfg/CMakeLists.txt
+++ b/api-tests/tools/scripts/target_cfg/CMakeLists.txt
@@ -63,8 +63,6 @@ add_executable(${PROJECT_NAME} ${TGT_CONFIG_SOURCE_C})
 foreach(include_path ${TARGET_HEADER_GEN_INCLUDE_PATHS})
 	target_include_directories(${PROJECT_NAME} PRIVATE ${include_path})
 endforeach()
-set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-m32 -w")
-set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-m32")
 
 # Adding target to tell we want OUTPUT_HEADER
 add_custom_target(


### PR DESCRIPTION
In #229 the 32-bit host compiler dependencies were first removed, but #255 somehow reverted some of the lines. This commit redoes the fix.

@jk-arm This fixes the build on macOS. Some newer Linux distributions also stopped supporting 32-bit.