### PR TITLE
Change the 'type' positive maximum into 'INT16_MAX'

### DIFF
--- a/api-tests/ff/ipc/test_i002/test_i002.c
+++ b/api-tests/ff/ipc/test_i002/test_i002.c
@@ -184,7 +184,7 @@ int32_t client_test_psa_call_with_allowed_type_values(caller_security_t caller _
 {
    int32_t            status = VAL_STATUS_SUCCESS;
    psa_handle_t       handle = 0;
-   int32_t            type[] = {PSA_IPC_CALL, 1, 2, INT32_MAX};
+   int16_t            type[] = {PSA_IPC_CALL, 1, 2, INT16_MAX};
    uint32_t           i = 0;
 
    val->print(PRINT_TEST, "[Check 5] Test psa_call with different type values\n", 0);

--- a/api-tests/ff/ipc/test_i002/test_supp_i002.c
+++ b/api-tests/ff/ipc/test_i002/test_supp_i002.c
@@ -187,7 +187,7 @@ int32_t server_test_psa_call_with_allowed_type_values(void)
 {
     int32_t         status = VAL_STATUS_SUCCESS;
     psa_msg_t       msg = {0};
-    int32_t         type[] = {PSA_IPC_CALL, 1, 2, INT32_MAX};
+    int16_t         type[] = {PSA_IPC_CALL, 1, 2, INT16_MAX};
     uint32_t        i = 0;
 
     status = ((val->process_connect_request(SERVER_UNSPECIFED_VERSION_SIGNAL, &msg))


### PR DESCRIPTION
A particular implementation MAY encode 'inlen', 'outlen', and 'type' into
one 32-bit integer to improve performance for parameter packing, which
makes the positive maximum INT32_MAX fail in the test - TF-M is now
encoding this way experimentally.

Change the positive maximum value as 'INT16_MAX' to assist the test.

Signed-off-by: Shawn Shan <Shawn.Shan@arm.com>
Change-Id: Ia8348cf0ef79b9a07cc6e89b074ccb6f604b8401