### PR TITLE
cmake: api-tests: Allow CROSS_COMPILE to set C compiler

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -435,6 +435,14 @@ ExternalProject_Add(
         TEST_COMMAND ""
 )
 
+# Check if a specific cross compiler was passed in
+find_program(CMAKE_C_COMPILER ${CROSS_COMPILE}-gcc)
+
+# Otherwise, let CMake look for a C compiler
+if(CMAKE_C_COMPILER STREQUAL "CMAKE_C_COMPILER-NOTFOUND")
+	project(TargetConfigGen LANGUAGES C)
+endif()
+
 # Add custom target to clean generated files of the external project
 add_custom_target(
         ${PSA_TARGET_GENERATE_DATABASE_POST}

--- a/api-tests/tools/scripts/target_cfg/CMakeLists.txt
+++ b/api-tests/tools/scripts/target_cfg/CMakeLists.txt
@@ -25,9 +25,6 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../../tools/cmake)
 include("common/CMakeSettings")
 include("common/Utils")
 
-# Let the CMake look for C compiler
-project(TargetConfigGen LANGUAGES C)
-
 # Check whether required arguments are passed to CMake
 _check_arguments("OUT_DIR"
 		"TARGET"


### PR DESCRIPTION
Cmake currently falls back to the default C compiler on the system,
which may not be an appropriate embedded toolchain in every case.

This commit checks for a `CROSS_COMPILE` field that can be
passed in to indicate the specific GCC cross-compiler to use. If no
matching value is found, it defaults to the system C compiler,
as was the case previously.

Fixes https://github.com/ARM-software/psa-arch-tests/issues/265

See also: https://github.com/zephyrproject-rtos/zephyr/issues/34962

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>