### PR TITLE
Add ARMCLANG to the list of cross compile toolchains

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -112,6 +112,7 @@ list(APPEND PSA_TOOLCHAIN_SUPPORT
 # list of supported CROSS_COMPILE toolchains
 list(APPEND CROSS_COMPILE_TOOLCHAIN_SUPPORT
         GNUARM
+        ARMCLANG
 )
 
 # list of suported CPU arch

--- a/tbsa-v8m/CMakeLists.txt
+++ b/tbsa-v8m/CMakeLists.txt
@@ -66,11 +66,13 @@ list(APPEND ARCHITECTURE_SUPPORT
 # Supported toolchains
 list(APPEND TOOLCHAIN_SUPPORT
 	GNUARM
+	ARMCLANG
 )
 
 # list of supported CROSS_COMPILE toolchains
 list(APPEND CROSS_COMPILE_TOOLCHAIN_SUPPORT
 	GNUARM
+	ARMCLANG
 )
 
 # Variables of the project


### PR DESCRIPTION
In trusted-firmware-m, CROSS_COMPILE is set for all supported
toolchains. For ARMCLANG, it's used in

    set(CMAKE_C_COMPILER_TARGET      arm-${CROSS_COMPILE})

But if ARMCLANG is not in the list of cross compile toolchains in
psa-arch-tests, we get the following error when we build the tests
with trusted-firmware-m:

    [PSA] : Error: CROSS_COMPILE not supported for this toolchain, supported..
    toolchain are : GNUARM..