### PR TITLE
Fix incorrect key derivation operation handle init

### DIFF
--- a/api-tests/dev_apis/crypto/test_c018/test_c018.c
+++ b/api-tests/dev_apis/crypto/test_c018/test_c018.c
@@ -144,7 +144,7 @@ int32_t psa_key_derivation_input_key_negative_test(caller_security_t caller __UN
     val->print(PRINT_TEST, "[Check %d] Test psa_cipher_decrypt_setup - Invalid key handle\n",
                                                                                g_test_count++);
 
-    memset(&operation, 0, sizeof(operation));
+    operation = psa_key_derivation_operation_init();
 
     /* Set up a key derivation operation */
     status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_SETUP, &operation,
@@ -160,15 +160,15 @@ int32_t psa_key_derivation_input_key_negative_test(caller_security_t caller __UN
     status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &operation);
     TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(5));
 
+    val->print(PRINT_TEST, "[Check %d] Test psa_cipher_decrypt_setup - Zero as key handle\n",
+                                                                               g_test_count++);
+
+    operation = psa_key_derivation_operation_init();
+
     /* Set up a key derivation operation */
     status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_SETUP, &operation,
              check1[valid_test_input_index].setup_alg);
     TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(6));
-
-    val->print(PRINT_TEST, "[Check %d] Test psa_cipher_decrypt_setup - Zero as key handle\n",
-                                                                               g_test_count++);
-
-    memset(&operation, 0, sizeof(operation));
 
     /* Provide an input for key derivation or key agreement */
     status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_INPUT_KEY, &operation,


### PR DESCRIPTION
The key derivation operation handle is zeroed after key derivation setup
completes, when testing zero key handle in
psa_key_derivation_input_key_negative_test().
Therefore, both operation handle and key handle are invalid during test.
The return result becomes implementation defined, depending on whether
SPE checks operation or key at first.

Move key derivation operation handle init before key derivation setup,
to make sure the operation is valid.
Move the test log dump as well accordingly.

Signed-off-by: David Hu <david.hu@arm.com>