### PR TITLE
val: Fix compilation issue when watchdog is not used

### DIFF
--- a/api-tests/val/nspe/val_peripherals.c
+++ b/api-tests/val/nspe/val_peripherals.c
@@ -158,6 +158,7 @@ val_status_t val_wd_reprogram_timer(wd_timeout_type_t timeout_type)
 {
     val_status_t    status = VAL_STATUS_SUCCESS;
 
+    (void)timeout_type; // Argument unused if WATCHDOG_AVAILABLE is not defined
 #ifdef WATCHDOG_AVAILABLE
     /* Disable watchdog Timer */
     val_wd_timer_disable();


### PR DESCRIPTION
If watchdog is not available, compilation will fail as the val_wd_reprogram_timer
has an unused argument. Added void cast to remove compilation error.

Signed-off-by: Andreas Vibeto <andreas.vibeto@nordicsemi.no>