### PR TITLE
Use PSA_KEY_TYPE_DES instead of PSA_KEY_TYPE_ARC4

### DIFF
--- a/api-tests/dev_apis/crypto/test_c032/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c032/test_data.h
@@ -152,10 +152,10 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CIPHER_MODE_CTR
-#ifdef ARCH_TEST_ARC4
+#ifdef ARCH_TEST_DES
 {
     .test_desc       = "Test psa_cipher_encrypt_setup - incompatible key ARC4\n",
-    .type            = PSA_KEY_TYPE_ARC4,
+    .type            = PSA_KEY_TYPE_DES,
     .data            = key_data,
     .data_length     = AES_16B_KEY_SIZE,
     .bits            = BYTES_TO_BITS(AES_16B_KEY_SIZE),

--- a/api-tests/dev_apis/crypto/test_c033/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c033/test_data.h
@@ -142,10 +142,10 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CIPHER_MODE_CTR
-#ifdef ARCH_TEST_ARC4
+#ifdef ARCH_TEST_DES
 {
     .test_desc       = "Test psa_cipher_decrypt_setup - incompatible key ARC4\n",
-    .type            = PSA_KEY_TYPE_ARC4,
+    .type            = PSA_KEY_TYPE_DES,
     .data            = key_data,
     .data_length     = AES_16B_KEY_SIZE,
     .usage_flags     = PSA_KEY_USAGE_DECRYPT,


### PR DESCRIPTION
The ARC4 key type has been removed from the released PSA crypto 1.0,
which prevents the test suite from building with Mbed TLS 3 headers.

Use `PSA_KEY_TYPE_DES` instead for negative testing instead.