### PR TITLE
Change error code for using an asymmetric public key with psa_generate_key to align with the spec

### DIFF
--- a/api-tests/dev_apis/crypto/test_c016/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c016/test_data.h
@@ -150,7 +150,7 @@ static const test_data check1[] = {
     .expected_range  = {1, BITS_TO_BYTES(MIN(PSA_EXPORT_KEY_OUTPUT_SIZE(\
 	                    PSA_KEY_TYPE_RSA_PUBLIC_KEY, 2048), \
                         PSA_EXPORT_PUBLIC_KEY_MAX_SIZE))},
-    .expected_status = PSA_ERROR_NOT_SUPPORTED
+    .expected_status = PSA_ERROR_INVALID_ARGUMENT
 },
 #endif
 #endif


### PR DESCRIPTION
In `psa_generate_key` tests (test_c016) ("Test psa_generate_key with RSA 2048 Public key"):

Changed the error code from `PSA_ERROR_NOT_SUPPORTED` to
`PSA_ERROR_INVALID_ARGUMENT` as in the documentation of
`psa_generate_key()` returned values:
"`PSA_ERROR_INVALID_ARGUMENT` The key type is an asymmetric public key type."

See:
ARMmbed/mbedtls#4551
ARMmbed/mbedtls#5037
ARMmbed/mbedtls#5038