### PR TITLE
Enable testing of all functions implemented in Mbed TLS 2.28

### DIFF
--- a/api-tests/dev_apis/crypto/suite.cmake
+++ b/api-tests/dev_apis/crypto/suite.cmake
@@ -33,7 +33,9 @@ endforeach()
 
 add_definitions(${CC_OPTIONS})
 add_definitions(${AS_OPTIONS})
-add_definitions(-DMISSING_CRYPTO_1_0=0)
+
+set(MISSING_CRYPTO_1_0 0 CACHE INTERNAL "Disable calls to crypto functions missing from Mbed TLS 2.x")
+add_definitions(-DMISSING_CRYPTO_1_0=${MISSING_CRYPTO_1_0})
 
 # append common crypto file to list of source collected
 list(APPEND SUITE_CC_SOURCE ${PSA_SUITE_DIR}/common/test_crypto_common.c)

--- a/api-tests/platform/targets/common/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/common/nspe/crypto/pal_crypto_intf.c
@@ -701,7 +701,6 @@ int32_t pal_crypto_function(int type, va_list valist)
 								  input,
 								  input_length);
 			break;
-#if MISSING_CRYPTO_1_0 == 0
 		case PAL_CRYPTO_MAC_VERIFY:
 			key                      = va_arg(valist, psa_key_id_t);
 			alg                      = va_arg(valist, psa_algorithm_t);
@@ -716,7 +715,6 @@ int32_t pal_crypto_function(int type, va_list valist)
 								  input1,
 								  input_length1);
 			break;
-#endif
 		case PAL_CRYPTO_MAC_VERIFY_FINISH:
 			mac_operation            = va_arg(valist, psa_mac_operation_t *);
 			input                    = va_arg(valist, const uint8_t *);

--- a/api-tests/platform/targets/common/nspe/crypto/pal_crypto_intf.c
+++ b/api-tests/platform/targets/common/nspe/crypto/pal_crypto_intf.c
@@ -270,7 +270,6 @@ int32_t pal_crypto_function(int type, va_list valist)
 			cipher_operation         =  va_arg(valist, psa_cipher_operation_t *);
 			return psa_cipher_abort(cipher_operation);
 			break;
-#if MISSING_CRYPTO_1_0 == 0
 		case PAL_CRYPTO_CIPHER_DECRYPT:
 			key                      = va_arg(valist, psa_key_id_t);
 			alg                      = va_arg(valist, psa_algorithm_t);
@@ -287,7 +286,6 @@ int32_t pal_crypto_function(int type, va_list valist)
 									  output_size,
 									  p_output_length);
 			break;
-#endif
 		case PAL_CRYPTO_CIPHER_DECRYPT_SETUP:
 			cipher_operation         = va_arg(valist, psa_cipher_operation_t *);
 			key                      = va_arg(valist, psa_key_id_t);
@@ -296,7 +294,6 @@ int32_t pal_crypto_function(int type, va_list valist)
 											key,
 											alg);
 			break;
-#if MISSING_CRYPTO_1_0 == 0
 		case PAL_CRYPTO_CIPHER_ENCRYPT:
 			key                      = va_arg(valist, psa_key_id_t);
 			alg                      = va_arg(valist, psa_algorithm_t);
@@ -313,7 +310,6 @@ int32_t pal_crypto_function(int type, va_list valist)
 									  output_size,
 									  p_output_length);
 			break;
-#endif
 		case PAL_CRYPTO_CIPHER_ENCRYPT_SETUP:
 			cipher_operation         = va_arg(valist, psa_cipher_operation_t *);
 			key                      = va_arg(valist, psa_key_id_t);


### PR DESCRIPTION
Mbed TLS 2.28 implements  some, but not all functions currently gated behind `MISSING_CRYPTO_1_0`.

Fully enable these functions, and allow setting MISSING_CRYPTO_1_0 from the command line, without editing the source of the compliance test suite.