### PR TITLE
Minor cleanup

### DIFF
--- a/api-tests/ff/ipc/stateless_rot_testsuite.db
+++ b/api-tests/ff/ipc/stateless_rot_testsuite.db
@@ -86,7 +86,7 @@ test_i084, panic_test
 test_i085, panic_test
 test_i086, panic_test
 test_i087, panic_test
-test_l088
+test_i088
 test_i089, panic_test
 test_i090, panic_test
 

--- a/api-tests/ff/ipc/test_i082/test_i082.c
+++ b/api-tests/ff/ipc/test_i082/test_i082.c
@@ -204,9 +204,11 @@ int32_t client_test_app_rot_read_psa_rot_heap(caller_security_t caller __UNUSED)
    if (VAL_ERROR(get_secure_partition_address(&handle,
                                               &psa_rot_addr,
                                               TEST_ISOLATION_PSA_ROT_HEAP_RD)))
+    {
        return VAL_STATUS_ERROR;
+    }
 
-       close_driver_fn(&handle);
+   close_driver_fn(&handle);
 
    /* Setting boot.state before test check */
    if (val->set_boot_flag(BOOT_EXPECTED_REENTER_TEST))

--- a/api-tests/ff/ipc/test_i088/test.cmake
+++ b/api-tests/ff/ipc/test_i088/test.cmake
@@ -16,16 +16,16 @@
 #**/
 
 list(APPEND CC_SOURCE
-	test_entry_l088.c
-	test_l088.c
+	test_entry_i088.c
+	test_i088.c
 )
 list(APPEND CC_OPTIONS )
 list(APPEND AS_SOURCE  )
 list(APPEND AS_OPTIONS )
 
 list(APPEND CC_SOURCE_SPE
-	test_l088.c
-	test_supp_l088.c
+	test_i088.c
+	test_supp_i088.c
 )
 list(APPEND CC_OPTIONS_SPE )
 list(APPEND AS_SOURCE_SPE  )

--- a/api-tests/ff/ipc/test_i088/test_entry_i088.c
+++ b/api-tests/ff/ipc/test_i088/test_entry_i088.c
@@ -17,7 +17,7 @@
 
 #include "val_interfaces.h"
 #include "val_target.h"
-#include "test_l088.h"
+#include "test_i088.h"
 
 #define TEST_NUM  VAL_CREATE_TEST_ID(VAL_FF_BASE, 88)
 #define TEST_DESC "Testing psa_rot_lifecycle_state API\n"

--- a/api-tests/ff/ipc/test_i088/test_i088.c
+++ b/api-tests/ff/ipc/test_i088/test_i088.c
@@ -23,9 +23,9 @@
 #include "val_service_defs.h"
 #endif
 
-#include "test_l088.h"
+#include "test_i088.h"
 
-const client_test_t test_l088_client_tests_list[] = {
+const client_test_t test_i088_client_tests_list[] = {
     NULL,
     client_test_psa_rot_lifecycle_state,
     NULL,

--- a/api-tests/ff/ipc/test_i088/test_i088.h
+++ b/api-tests/ff/ipc/test_i088/test_i088.h
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 **/
-#ifndef _TEST_L088_CLIENT_TESTS_H_
-#define _TEST_L088_CLIENT_TESTS_H_
+#ifndef _TEST_I088_CLIENT_TESTS_H_
+#define _TEST_I088_CLIENT_TESTS_H_
 
 #include "val_client_defs.h"
 
 #ifdef NONSECURE_TEST_BUILD
-#define test_entry CONCAT(test_entry_, l088)
+#define test_entry CONCAT(test_entry_, i088)
 #define val CONCAT(val, test_entry)
 #define psa CONCAT(psa, test_entry)
 #else

--- a/api-tests/ff/ipc/test_i088/test_supp_i088.c
+++ b/api-tests/ff/ipc/test_i088/test_supp_i088.c
@@ -25,7 +25,7 @@ extern psa_api_t *psa;
 
 int32_t server_test_psa_rot_lifecycle_state(void);
 
-const server_test_t test_l088_server_tests_list[] = {
+const server_test_t test_i088_server_tests_list[] = {
     NULL,
     server_test_psa_rot_lifecycle_state,
     NULL,

--- a/api-tests/ff/ipc/testsuite.db
+++ b/api-tests/ff/ipc/testsuite.db
@@ -107,7 +107,7 @@ test_i084, panic_test
 test_i085, panic_test
 test_i086, panic_test
 test_i087, panic_test
-test_l088
+test_i088
 test_i089, panic_test
 test_i090, panic_test
 


### PR DESCRIPTION
Fix indentation causing a build warning, and rename test_l088 to test_i088 (assuming the 'L' is a typo)