### PR TITLE
nordic: Use hardware WDT for DEV APIs tests

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/nspe/pal_driver_intf.c
@@ -18,6 +18,8 @@
 #include "pal_common.h"
 #include "pal_nvmem.h"
 
+#include "nrf_wdt.h"
+
 /**
     @brief    - This function initializes the UART
     @param    - uart base addr
@@ -51,9 +53,8 @@ int pal_print_ns(const char *str, int32_t data)
 **/
 int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
 {
-    (void)base_addr;
-    pal_timer_init_ns(time_us * timer_tick_us);
-    return PAL_STATUS_SUCCESS;
+    (void)timer_tick_us;
+    return nrf_wdt_init(base_addr, time_us);
 }
 
 /**
@@ -63,9 +64,7 @@ int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick
 **/
 int pal_wd_timer_enable_ns(addr_t base_addr)
 {
-    (void)base_addr;
-    pal_timer_start_ns();
-    return PAL_STATUS_SUCCESS;
+    return nrf_wdt_enable(base_addr);
 
 }
 
@@ -76,9 +75,7 @@ int pal_wd_timer_enable_ns(addr_t base_addr)
 **/
 int pal_wd_timer_disable_ns(addr_t base_addr)
 {
-    (void)base_addr;
-    pal_timer_stop_ns();
-    return PAL_STATUS_SUCCESS;
+    return nrf_wdt_disable(base_addr);
 }
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cfg
@@ -21,12 +21,12 @@ uart.0.base = 0; // Unused value
 
 // Watchdog device info
 watchdog.num = 1;
-watchdog.0.base = 0; // Unused value
+watchdog.0.base = 0x40018000; // Unused value
 watchdog.0.num_of_tick_per_micro_sec = 1;
-watchdog.0.timeout_in_micro_sec_low = 60000000; //60 secs
-watchdog.0.timeout_in_micro_sec_medium = 60000000; //60 secs
-watchdog.0.timeout_in_micro_sec_high = 60000000; //60 secs
-watchdog.0.timeout_in_micro_sec_crypto = 60000000; //60 secs
+watchdog.0.timeout_in_micro_sec_low = 1000000; // 1.0 secs
+watchdog.0.timeout_in_micro_sec_medium = 2000000;  // 2 secs
+watchdog.0.timeout_in_micro_sec_high = 5000000; // 5 secs
+watchdog.0.timeout_in_micro_sec_crypto = 18000000; // 18 secs
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cmake
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/target.cmake
@@ -35,6 +35,7 @@ else()
 		# driver files will be compiled as part of NSPE
 		${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/pal_driver_intf.c
 		${PSA_ROOT_DIR}/platform/drivers/nvmem/pal_nvmem.c
+		${PSA_ROOT_DIR}/platform/drivers/watchdog/nrf/nrf_wdt.c
 	)
 endif()
 
@@ -79,6 +80,7 @@ target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
 	${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage
 	${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation
 	${PSA_ROOT_DIR}/platform/drivers/nvmem
+	${PSA_ROOT_DIR}/platform/drivers/watchdog/nrf/
 	${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe
 )
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/nspe/pal_driver_intf.c
@@ -18,6 +18,8 @@
 #include "pal_common.h"
 #include "pal_nvmem.h"
 
+#include "nrf_wdt.h"
+
 /**
     @brief    - This function initializes the UART
     @param    - uart base addr
@@ -51,9 +53,8 @@ int pal_print_ns(const char *str, int32_t data)
 **/
 int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick_us)
 {
-    (void)base_addr;
-    pal_timer_init_ns(time_us * timer_tick_us);
-    return PAL_STATUS_SUCCESS;
+    (void)timer_tick_us;
+    return nrf_wdt_init(base_addr, time_us);
 }
 
 /**
@@ -63,10 +64,7 @@ int pal_wd_timer_init_ns(addr_t base_addr, uint32_t time_us, uint32_t timer_tick
 **/
 int pal_wd_timer_enable_ns(addr_t base_addr)
 {
-    (void)base_addr;
-    pal_timer_start_ns();
-    return PAL_STATUS_SUCCESS;
-
+    return nrf_wdt_enable(base_addr);
 }
 
 /**
@@ -76,9 +74,7 @@ int pal_wd_timer_enable_ns(addr_t base_addr)
 **/
 int pal_wd_timer_disable_ns(addr_t base_addr)
 {
-    (void)base_addr;
-    pal_timer_stop_ns();
-    return PAL_STATUS_SUCCESS;
+    return nrf_wdt_disable(base_addr);
 }
 
 /**

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cfg
@@ -21,12 +21,14 @@ uart.0.base = 0; // Unused value
 
 // Watchdog device info
 watchdog.num = 1;
-watchdog.0.base = 0; // Unused value
+watchdog.0.base = 0x40018000;
 watchdog.0.num_of_tick_per_micro_sec = 1;
-watchdog.0.timeout_in_micro_sec_low = 60000000; //60 secs
-watchdog.0.timeout_in_micro_sec_medium = 60000000; //60 secs
-watchdog.0.timeout_in_micro_sec_high = 60000000; //60 secs
-watchdog.0.timeout_in_micro_sec_crypto = 60000000; //60 secs
+// The same value should be used for all timeout durations, as the nRF91
+// WDT cannot be reconfigured once it has been started.
+watchdog.0.timeout_in_micro_sec_low = 18000000; // 18 secs
+watchdog.0.timeout_in_micro_sec_medium = 18000000;  // 18 secs
+watchdog.0.timeout_in_micro_sec_high = 18000000; // 18 secs
+watchdog.0.timeout_in_micro_sec_crypto = 18000000; // 18 secs
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cmake
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/target.cmake
@@ -35,6 +35,7 @@ else()
 		# driver files will be compiled as part of NSPE
 		${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/pal_driver_intf.c
 		${PSA_ROOT_DIR}/platform/drivers/nvmem/pal_nvmem.c
+		${PSA_ROOT_DIR}/platform/drivers/watchdog/nrf/nrf9160_wdt.c
 	)
 endif()
 
@@ -79,6 +80,7 @@ target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
 	${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage
 	${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation
 	${PSA_ROOT_DIR}/platform/drivers/nvmem
+	${PSA_ROOT_DIR}/platform/drivers/watchdog/nrf/
 	${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe
 )
 


### PR DESCRIPTION
Use the hardware watchdog timer insted of hardware timer for DEV APIs tests

Reviewed internally.