### PR TITLE
Crypto tests 224/225 allow multiple return values

### DIFF
--- a/api-tests/dev_apis/crypto/test_c024/test_c024.c
+++ b/api-tests/dev_apis/crypto/test_c024/test_c024.c
@@ -79,7 +79,10 @@ int32_t psa_aead_encrypt_test(caller_security_t caller __UNUSED)
                                       check1[i].ciphertext,
                                       check1[i].ciphertext_size,
                                       &get_ciphertext_length);
-        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(4));
+        TEST_ASSERT_DUAL(status,
+                         check1[i].expected_status[0],
+                         check1[i].expected_status[1],
+                         TEST_CHECKPOINT_NUM(4));
 
         if (check1[i].expected_status != PSA_SUCCESS)
         {

--- a/api-tests/dev_apis/crypto/test_c024/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c024/test_data.h
@@ -34,7 +34,7 @@ typedef struct {
     const uint8_t          *expected_ciphertext;
     size_t                  ciphertext_size;
     size_t                  expected_ciphertext_length;
-    psa_status_t            expected_status;
+    psa_status_t            expected_status[2];
 } test_data;
 
 static const test_data check1[] = {
@@ -57,7 +57,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_1,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_1,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -77,7 +77,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_2,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_2,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -97,7 +97,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_3,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_3,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -117,7 +117,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_4,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_4,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -137,7 +137,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_5,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_5,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 #endif
 #endif
@@ -161,7 +161,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_6,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_6,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 #endif
 #endif
@@ -185,7 +185,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = NULL,
     .ciphertext_size            = 0,
     .expected_ciphertext_length = 0,
-    .expected_status            = PSA_ERROR_NOT_SUPPORTED
+    .expected_status            = {PSA_ERROR_NOT_SUPPORTED, PSA_ERROR_INVALID_ARGUMENT}
 },
 
 {
@@ -205,7 +205,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = NULL,
     .ciphertext_size            = 0,
     .expected_ciphertext_length = 0,
-    .expected_status            = PSA_ERROR_NOT_PERMITTED
+    .expected_status            = {PSA_ERROR_NOT_PERMITTED, PSA_ERROR_NOT_PERMITTED}
 },
 
 {
@@ -225,7 +225,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_2,
     .ciphertext_size            = AEAD_CIPHERTEXT_LEN_2-1,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_2,
-    .expected_status            = PSA_ERROR_BUFFER_TOO_SMALL
+    .expected_status            = {PSA_ERROR_BUFFER_TOO_SMALL, PSA_ERROR_BUFFER_TOO_SMALL}
 },
 
 {
@@ -245,7 +245,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_2,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_2,
-    .expected_status            = PSA_ERROR_INVALID_ARGUMENT
+    .expected_status            = {PSA_ERROR_INVALID_ARGUMENT, PSA_ERROR_INVALID_ARGUMENT}
 },
 
 {
@@ -265,7 +265,7 @@ static const test_data check1[] = {
     .expected_ciphertext        = aead_ciphertext_2,
     .ciphertext_size            = BUFFER_SIZE,
     .expected_ciphertext_length = AEAD_CIPHERTEXT_LEN_2,
-    .expected_status            = PSA_ERROR_INVALID_ARGUMENT
+    .expected_status            = {PSA_ERROR_INVALID_ARGUMENT, PSA_ERROR_INVALID_ARGUMENT}
 },
 #endif
 #endif

--- a/api-tests/dev_apis/crypto/test_c025/test_c025.c
+++ b/api-tests/dev_apis/crypto/test_c025/test_c025.c
@@ -70,7 +70,10 @@ int32_t psa_aead_decrypt_test(caller_security_t caller __UNUSED)
                                       check1[i].ciphertext, check1[i].ciphertext_length,
                                       check1[i].plaintext, check1[i].plaintext_size,
                                       &expected_plaintext_length);
-        TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(4));
+        TEST_ASSERT_DUAL(status,
+                         check1[i].expected_status[0],
+                         check1[i].expected_status[1],
+                         TEST_CHECKPOINT_NUM(4));
 
         if (check1[i].expected_status != PSA_SUCCESS)
         {

--- a/api-tests/dev_apis/crypto/test_c025/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c025/test_data.h
@@ -34,7 +34,7 @@ typedef struct {
     const uint8_t          *expected_plaintext;
     size_t                  plaintext_size;
     size_t                  expected_plaintext_length;
-    psa_status_t            expected_status;
+    psa_status_t            expected_status[2];
 } test_data;
 
 static const test_data check1[] = {
@@ -57,7 +57,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 23,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -77,7 +77,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -97,7 +97,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -117,7 +117,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 
 {
@@ -137,7 +137,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 0,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 #endif
 #endif
@@ -161,7 +161,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_SUCCESS
+    .expected_status            = {PSA_SUCCESS, PSA_SUCCESS}
 },
 #endif
 #endif
@@ -185,7 +185,7 @@ static const test_data check1[] = {
     .expected_plaintext         = NULL,
     .plaintext_size             = 0,
     .expected_plaintext_length  = 0,
-    .expected_status            = PSA_ERROR_NOT_SUPPORTED
+    .expected_status            = {PSA_ERROR_NOT_SUPPORTED, PSA_ERROR_INVALID_ARGUMENT}
 },
 
 {
@@ -205,7 +205,7 @@ static const test_data check1[] = {
     .expected_plaintext         = NULL,
     .plaintext_size             = 0,
     .expected_plaintext_length  = 0,
-    .expected_status            = PSA_ERROR_NOT_PERMITTED
+    .expected_status            = {PSA_ERROR_NOT_PERMITTED, PSA_ERROR_NOT_PERMITTED}
 },
 
 {
@@ -225,7 +225,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = 23,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_ERROR_BUFFER_TOO_SMALL
+    .expected_status            = {PSA_ERROR_BUFFER_TOO_SMALL, PSA_ERROR_BUFFER_TOO_SMALL}
 },
 
 {
@@ -245,7 +245,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_ERROR_INVALID_ARGUMENT
+    .expected_status            = {PSA_ERROR_INVALID_ARGUMENT, PSA_ERROR_INVALID_ARGUMENT}
 },
 
 {
@@ -265,7 +265,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_ERROR_INVALID_SIGNATURE
+    .expected_status            = {PSA_ERROR_INVALID_SIGNATURE, PSA_ERROR_INVALID_SIGNATURE}
 },
 
 {
@@ -285,7 +285,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_ERROR_INVALID_SIGNATURE
+    .expected_status            = {PSA_ERROR_INVALID_SIGNATURE, PSA_ERROR_INVALID_SIGNATURE}
 },
 
 {
@@ -305,7 +305,7 @@ static const test_data check1[] = {
     .expected_plaintext         = plaintext,
     .plaintext_size             = BUFFER_SIZE,
     .expected_plaintext_length  = 24,
-    .expected_status            = PSA_ERROR_INVALID_ARGUMENT
+    .expected_status            = {PSA_ERROR_INVALID_ARGUMENT, PSA_ERROR_INVALID_ARGUMENT}
 },
 #endif
 #endif


### PR DESCRIPTION
As described in #307,  unsupported algorithm check for tests 224 and 225 should allow both `PSA_ERROR_NOT_SUPPORTED` and `PSA_ERROR_INVALID_ARGUMENT` as accepted results.