### PR TITLE
ff: Fix server test function names

### DIFF
--- a/api-tests/ff/ipc/test_i065/test_supp_i065.c
+++ b/api-tests/ff/ipc/test_i065/test_supp_i065.c
@@ -23,11 +23,11 @@
 extern val_api_t *val;
 extern psa_api_t *psa;
 
-int32_t server_test_psa_eoi_with_non_intr_signal(void);
+int32_t server_test_psa_eoi_with_unasserted_signal(void);
 
 const server_test_t test_i065_server_tests_list[] = {
     NULL,
-    server_test_psa_eoi_with_non_intr_signal,
+    server_test_psa_eoi_with_unasserted_signal,
     NULL,
 };
 

--- a/api-tests/ff/ipc/test_i066/test_supp_i066.c
+++ b/api-tests/ff/ipc/test_i066/test_supp_i066.c
@@ -23,11 +23,11 @@
 extern val_api_t *val;
 extern psa_api_t *psa;
 
-int32_t server_test_psa_eoi_with_non_intr_signal(void);
+int32_t server_test_psa_eoi_with_multiple_signals(void);
 
 const server_test_t test_i066_server_tests_list[] = {
     NULL,
-    server_test_psa_eoi_with_non_intr_signal,
+    server_test_psa_eoi_with_multiple_signals,
     NULL,
 };
 


### PR DESCRIPTION
Update test_i065 and test_i066 to call the correct test functions on
the server side (previously called server test function from
test_i064, but as the three functions only return SUCCESS this has
not had a functional impact)