### PR TITLE
Skip tests when failure are due to unimplemented functions in the PAL layer for the specific platform

### DIFF
--- a/api-tests/val/common/val.h
+++ b/api-tests/val/common/val.h
@@ -123,6 +123,10 @@
 
 #define TEST_ASSERT_EQUAL(arg1, arg2, checkpoint)                                   \
     do {                                                                            \
+        if ((arg1) == PAL_STATUS_UNSUPPORTED_FUNC)                                  \
+        {                                                                           \
+            return RESULT_SKIP(VAL_STATUS_UNSUPPORTED);                             \
+        }                                                                           \
         if ((arg1) != arg2)                                                         \
         {                                                                           \
             val->print(PRINT_ERROR, "\tFailed at Checkpoint: %d\n", checkpoint);    \
@@ -134,6 +138,10 @@
 
 #define TEST_ASSERT_DUAL(arg1, status1, status2, checkpoint)                        \
     do {                                                                            \
+        if ((arg1) == PAL_STATUS_UNSUPPORTED_FUNC)                                  \
+        {                                                                           \
+            return RESULT_SKIP(VAL_STATUS_UNSUPPORTED);                             \
+        }                                                                           \
         if ((arg1) != status1 && (arg1) != status2)                                 \
         {                                                                           \
             val->print(PRINT_ERROR, "\tFailed at Checkpoint: %d\n", checkpoint);    \
@@ -153,6 +161,10 @@
 
 #define TEST_ASSERT_NOT_EQUAL(arg1, arg2, checkpoint)                               \
     do {                                                                            \
+        if ((arg1) == PAL_STATUS_UNSUPPORTED_FUNC)                                  \
+        {                                                                           \
+            return RESULT_SKIP(VAL_STATUS_UNSUPPORTED);                             \
+        }                                                                           \
         if ((arg1) == arg2)                                                         \
         {                                                                           \
             val->print(PRINT_ERROR, "\tFailed at Checkpoint: %d\n", checkpoint);    \
@@ -173,6 +185,10 @@
 
 #define TEST_ASSERT_RANGE(arg1, range1, range2, checkpoint)                         \
     do {                                                                            \
+        if ((arg1) == PAL_STATUS_UNSUPPORTED_FUNC)                                  \
+        {                                                                           \
+            return RESULT_SKIP(VAL_STATUS_UNSUPPORTED);                             \
+        }                                                                           \
         if ((arg1) < range1 || (arg1) > range2)                                     \
         {                                                                           \
             val->print(PRINT_ERROR, "\tFailed at Checkpoint: %d\n", checkpoint);    \


### PR DESCRIPTION
When an assertion is failing due to unsupported test, make sure
to return the TEST_SKIP bit so that the test is skipped instead
of failed. It helps on those platforms that don't implement API
which might be considered optionals.

Signed-off-by: Antonio de Angelis <antonio.deangelis@arm.com>