### PR TITLE
Fix output_length wrong judgment and correct nvmem.0.start for an521 dev apis

### DIFF
--- a/api-tests/dev_apis/crypto/test_c058/test_c058.c
+++ b/api-tests/dev_apis/crypto/test_c058/test_c058.c
@@ -139,7 +139,8 @@ int32_t psa_aead_update_test(caller_security_t caller __UNUSED)
             TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(9));
         } else {
             /* Compare the output and its length with the expected values */
-            TEST_ASSERT_RANGE(output_length, 0, check1[i].expected_output_length,
+            TEST_ASSERT_RANGE((int32_t)output_length, (int32_t)0,
+                              (int32_t)check1[i].expected_output_length,
                               TEST_CHECKPOINT_NUM(10));
             TEST_ASSERT_MEMCMP(check1[i].output, check1[i].expected_output, output_length,
                                TEST_CHECKPOINT_NUM(11));

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_an521/target.cfg
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_an521/target.cfg
@@ -36,6 +36,6 @@ watchdog.0.timeout_in_micro_sec_crypto = 0x1312D00; //18.0 sec : 18 * 1000 * 100
 
 // Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
 nvmem.num =1;
-nvmem.0.start = 0x28100000;
-nvmem.0.end = 0x281003FF;
+nvmem.0.start = 0x281FFC00;
+nvmem.0.end = 0x281FFFFF;
 nvmem.0.permission = TYPE_READ_WRITE;


### PR DESCRIPTION
1. output_length should be equal to expected_output_length in test_c058;
2. Previous nvmem.0.start address is conflict with tfm. Reserve 0x400 bytes for an521 psa arch dev apis test and update the nvmem.0.start address.