### PR TITLE
Crypto: Abort after failure on psa_hash_finish()

### DIFF
--- a/api-tests/dev_apis/crypto/test_c014/test_c014.c
+++ b/api-tests/dev_apis/crypto/test_c014/test_c014.c
@@ -72,18 +72,16 @@ int32_t psa_hash_finish_test(caller_security_t caller __UNUSED)
                                       check1[i].hash_size, &expected_hash_length);
         TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(5));
 
-        if (check1[i].expected_status != PSA_SUCCESS)
+        if (check1[i].expected_status == PSA_SUCCESS)
         {
-            continue;
+            TEST_ASSERT_EQUAL(expected_hash_length, check1[i].hash_size, TEST_CHECKPOINT_NUM(6));
+            TEST_ASSERT_MEMCMP(check1[i].expected_hash, check1[i].verify_hash,
+                               expected_hash_length, TEST_CHECKPOINT_NUM(7));
+        } else {
+            /*Abort the hash operation */
+            status = val->crypto_function(VAL_CRYPTO_HASH_ABORT, &operation);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
         }
-
-        TEST_ASSERT_EQUAL(expected_hash_length, check1[i].hash_size, TEST_CHECKPOINT_NUM(6));
-        TEST_ASSERT_MEMCMP(check1[i].expected_hash, check1[i].verify_hash,
-                           expected_hash_length, TEST_CHECKPOINT_NUM(7));
-
-        /*Abort the hash operation */
-        status = val->crypto_function(VAL_CRYPTO_HASH_ABORT, &operation);
-        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
 
         if (valid_test_input_index < 0)
             valid_test_input_index = i;


### PR DESCRIPTION
When a failure occurs on psa_hash_finish(), a multipart operation
must be explicitly terminated with a call to psa_hash_abort().
Make sure that test 214 follows this pattern to avoid any dangling
operation not being terminated.

Signed-off-by: Antonio de Angelis <Antonio.deAngelis@arm.com>