### PR TITLE
SHA-384 and SHA-512 are not supported in CC3XX PSA driver

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -641,6 +641,9 @@ endif()
 if(${SP_HEAP_MEM_SUPP} EQUAL 1)
 	add_definitions(-DSP_HEAP_MEM_SUPP)
 endif()
+if(${CC312_LEGACY_DRIVER_API_ENABLED})
+	add_definitions(-DCC312_LEGACY_DRIVER_API_ENABLED)
+endif()
 
 # Build PAL NSPE LIB
 include(${PSA_ROOT_DIR}/platform/targets/${TARGET}/target.cmake)

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_b1/nspe/pal_crypto_config.h
@@ -268,8 +268,10 @@
 #define ARCH_TEST_SHA256
 #ifndef TF_M_PROFILE_SMALL
 #ifndef TF_M_PROFILE_MEDIUM
+#ifdef CC312_LEGACY_DRIVER_API_ENABLED
 #define ARCH_TEST_SHA384
 #define ARCH_TEST_SHA512
+#endif
 #endif
 #endif
 //#define ARCH_TEST_SHA512_224

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_musca_s1/nspe/pal_crypto_config.h
@@ -268,8 +268,10 @@
 #define ARCH_TEST_SHA256
 #ifndef TF_M_PROFILE_SMALL
 #ifndef TF_M_PROFILE_MEDIUM
+#ifdef CC312_LEGACY_DRIVER_API_ENABLED
 #define ARCH_TEST_SHA384
 #define ARCH_TEST_SHA512
+#endif
 #endif
 #endif
 //#define ARCH_TEST_SHA512_224


### PR DESCRIPTION
For psa arch crypto test, SHA-384 and SHA-512 are not supported
in CC3XX PSA driver.

Signed-off-by: Summer Qin <summer.qin@arm.com>