### PR TITLE
Fix symmetric crypto output length tests

### DIFF
--- a/api-tests/dev_apis/crypto/test_c037/test_c037.c
+++ b/api-tests/dev_apis/crypto/test_c037/test_c037.c
@@ -110,19 +110,10 @@ int32_t psa_cipher_finish_test(caller_security_t caller __UNUSED)
             continue;
         }
 
-        if (check1[i].usage_flags == PSA_KEY_USAGE_ENCRYPT)
-        {
-		/* Check if the output length matches the expected length */
-		TEST_ASSERT_EQUAL(get_update_output_length + get_finish_output_length,
-					check1[i].expected_output_length,
-					TEST_CHECKPOINT_NUM(11));
-        }
-        else
-        {
-            /* Check if the output length matches the expected length */
-            TEST_ASSERT_EQUAL(get_finish_output_length, check1[i].expected_output_length,
-                              TEST_CHECKPOINT_NUM(11));
-        }
+        /* Check if the output length matches the expected length */
+        TEST_ASSERT_EQUAL(get_update_output_length + get_finish_output_length,
+                          check1[i].expected_output_length,
+                          TEST_CHECKPOINT_NUM(11));
 
         /* Check if the output data matches the expected data */
         TEST_ASSERT_MEMCMP(check1[i].output, check1[i].expected_output,

--- a/api-tests/dev_apis/crypto/test_c037/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c037/test_data.h
@@ -341,11 +341,11 @@ static const test_data check1[] = {
     .iv                     = iv,
     .iv_length              = 16,
     .input                  = ciphertext_2,
-    .input_length           = 16,
+    .input_length           = 15,
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 16,
+    .expected_output_length = 15,
     .expected_status        = PSA_SUCCESS
 },
 #endif

--- a/api-tests/dev_apis/crypto/test_c037/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c037/test_data.h
@@ -250,7 +250,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 0,
+    .expected_output_length = 16,
     .expected_status        = PSA_SUCCESS
 },
 
@@ -289,7 +289,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 0,
+    .expected_output_length = 16,
     .expected_status        = PSA_SUCCESS
 },
 
@@ -327,7 +327,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 0,
+    .expected_output_length = 16,
     .expected_status        = PSA_SUCCESS
 },
 
@@ -345,7 +345,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 0,
+    .expected_output_length = 16,
     .expected_status        = PSA_SUCCESS
 },
 #endif
@@ -367,7 +367,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 0,
+    .expected_output_length = 8,
     .expected_status        = PSA_SUCCESS
 },
 #endif
@@ -387,7 +387,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 0,
+    .expected_output_length = 8,
     .expected_status        = PSA_SUCCESS
 },
 #endif
@@ -407,7 +407,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = plaintext,
-    .expected_output_length = 0,
+    .expected_output_length = 8,
     .expected_status        = PSA_SUCCESS
 },
 #endif

--- a/api-tests/dev_apis/crypto/test_c037/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c037/test_data.h
@@ -168,7 +168,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = ciphertext_3,
-    .expected_output_length = 16,
+    .expected_output_length = 8,
     .expected_status        = PSA_SUCCESS
 },
 #endif
@@ -188,7 +188,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = ciphertext_4,
-    .expected_output_length = 0,
+    .expected_output_length = 8,
     .expected_status        = PSA_SUCCESS
 },
 #endif
@@ -208,7 +208,7 @@ static const test_data check1[] = {
     .output                 = expected_output,
     .output_size            = BUFFER_SIZE,
     .expected_output        = ciphertext_5,
-    .expected_output_length = 0,
+    .expected_output_length = 8,
     .expected_status        = PSA_SUCCESS
 },
 #endif


### PR DESCRIPTION
This PR fixes the following problems in the symmetric crypto tests (`test_c037`)
* The expected output length of DES/3DES encryption tests were incorrect.
* The output length of all encryption tests were calculated incorrectly.
* The `Decrypt - AES CTR (short input)` wasn't actually testing a short input.