### PR TITLE
Crypto: Fix duplicate checkpoint number in crypto test

### DIFF
--- a/api-tests/dev_apis/crypto/test_c034/test_c034.c
+++ b/api-tests/dev_apis/crypto/test_c034/test_c034.c
@@ -118,7 +118,7 @@ int32_t psa_cipher_generate_iv_test(caller_security_t caller __UNUSED)
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
         status = val->crypto_function(VAL_CRYPTO_IMPORT_KEY, &attributes, check1[i].data,
                                       check1[i].data_length, &key);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_NOT_SUPPORTED, TEST_CHECKPOINT_NUM(3));
+        TEST_ASSERT_EQUAL(status, PSA_ERROR_NOT_SUPPORTED, TEST_CHECKPOINT_NUM(13));
     }
 
     return VAL_STATUS_SUCCESS;


### PR DESCRIPTION
Fix duplicate checkpoint number in crypto test.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>