### PR TITLE
platform: nordic_nrf: Remove definition of unused functions

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf5340/nspe/pal_config.h
@@ -96,15 +96,6 @@
 extern int tfm_log_printf(const char *, ...);
 extern int32_t tfm_platform_system_reset(void);
 
-/* Initialize the timer with the given number of ticks. */
-extern void pal_timer_init_ns(uint32_t ticks);
-
-/* Start the timer. */
-extern void pal_timer_start_ns(void);
-
-/* Stop and reset the timer. */
-extern void pal_timer_stop_ns(void);
-
 /* Get the address of a free, word-aligned, 1K memory area. */
 extern uint32_t pal_nvmem_get_addr(void);
 

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_nrf9160/nspe/pal_config.h
@@ -96,15 +96,6 @@
 extern int tfm_log_printf(const char *, ...);
 extern int32_t tfm_platform_system_reset(void);
 
-/* Initialize the timer with the given number of ticks. */
-extern void pal_timer_init_ns(uint32_t ticks);
-
-/* Start the timer. */
-extern void pal_timer_start_ns(void);
-
-/* Stop and reset the timer. */
-extern void pal_timer_stop_ns(void);
-
 /* Get the address of a free, word-aligned, 1K memory area. */
 extern uint32_t pal_nvmem_get_addr(void);
 

--- a/api-tests/platform/targets/tgt_ff_tfm_nrf_common/nspe/pal_driver_ipc_intf.c
+++ b/api-tests/platform/targets/tgt_ff_tfm_nrf_common/nspe/pal_driver_ipc_intf.c
@@ -23,15 +23,6 @@
 
 extern int tfm_log_printf(const char *, ...);
 
-/* Initialize the timer with the given number of ticks. */
-extern void pal_timer_init_ns(uint32_t ticks);
-
-/* Start the timer. */
-extern void pal_timer_start_ns(void);
-
-/* Stop and reset the timer. */
-extern void pal_timer_stop_ns(void);
-
 /* Get the address of a free, word-aligned, 1K memory area. */
 extern uint32_t pal_nvmem_get_addr(void);
 


### PR DESCRIPTION
Remove definition of the unused pal_timer functions.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>