### PR TITLE
zephyr: module: Add module file for psa-arch-tests

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,1 @@
+name: psa-arch-tests


### PR DESCRIPTION
Add module file for psa-arch-tests repository.
This allows us to point this repository with a
ZEPHYR_<module>_MODULE_DIR variable when included by zephyr.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>