### PR TITLE
Change psa-arch-tests test functions

### DIFF
--- a/api-tests/dev_apis/crypto/test_c018/test_c018.c
+++ b/api-tests/dev_apis/crypto/test_c018/test_c018.c
@@ -92,10 +92,13 @@ int32_t psa_key_derivation_input_key_test(caller_security_t caller __UNUSED)
 
         if (check1[i].expected_status != PSA_SUCCESS)
         {
+            val->print(PRINT_TEST, "Aborting", 0);
             /* Abort the key derivation operation */
             status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &operation);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
 
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
             continue;
         }
 

--- a/api-tests/dev_apis/crypto/test_c019/test_c019.c
+++ b/api-tests/dev_apis/crypto/test_c019/test_c019.c
@@ -89,7 +89,12 @@ int32_t psa_key_derivation_key_agreement_test(caller_security_t caller __UNUSED)
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
 
         if (check1[i].expected_status != PSA_SUCCESS)
+        {
+            /* Destroy a key and restore the slot to its default state */
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
             continue;
+        }
 
         /* Destroy a key and restore the slot to its default state */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);

--- a/api-tests/dev_apis/crypto/test_c021/test_c021.c
+++ b/api-tests/dev_apis/crypto/test_c021/test_c021.c
@@ -153,6 +153,12 @@ int32_t psa_key_derivation_output_key_test(caller_security_t caller __UNUSED)
                                       &operation, &keys[SLOT_1]);
         TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(14));
 
+        if (check1[i].expected_status == PSA_SUCCESS)
+        {
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, keys[SLOT_1]);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(15));
+        }
+
         {
             status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(15));
@@ -179,6 +185,8 @@ int32_t psa_key_derivation_output_key_test(caller_security_t caller __UNUSED)
         status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_OUTPUT_KEY, &derv_attributes,
                                       &operation, &keys[SLOT_2]);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(19));
+
+
 
     }
     return VAL_STATUS_SUCCESS;


### PR DESCRIPTION
change test functions such that minimal amount of keys are stored at the same time