### PR TITLE
Optimize key usage

### DIFF
--- a/api-tests/dev_apis/crypto/test_c003/test_c003.c
+++ b/api-tests/dev_apis/crypto/test_c003/test_c003.c
@@ -78,7 +78,11 @@ int32_t psa_export_key_test(caller_security_t caller __UNUSED)
 
         /* If failure is expected, continue with the next data set */
         if (check1[i].expected_status != PSA_SUCCESS)
+        {
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
             continue;
+        }
 
         /* Check the attributes of the exported key */
         TEST_ASSERT_EQUAL(expected_data_length, check1[i].expected_data_length,

--- a/api-tests/dev_apis/crypto/test_c004/test_c004.c
+++ b/api-tests/dev_apis/crypto/test_c004/test_c004.c
@@ -80,7 +80,11 @@ int32_t test_psa_export_public_key(caller_security_t caller __UNUSED)
 
         /* If failure is expected, continue with the next data set */
         if (check1[i].expected_status != PSA_SUCCESS)
+        {
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
             continue;
+        }
 
         TEST_ASSERT_EQUAL(expected_data_length, check1[i].expected_data_length,
                           TEST_CHECKPOINT_NUM(5));

--- a/api-tests/dev_apis/crypto/test_c018/test_c018.c
+++ b/api-tests/dev_apis/crypto/test_c018/test_c018.c
@@ -96,6 +96,8 @@ int32_t psa_key_derivation_input_key_test(caller_security_t caller __UNUSED)
             status = val->crypto_function(VAL_CRYPTO_KEY_DERIVATION_ABORT, &operation);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
 
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
             continue;
         }
 

--- a/api-tests/dev_apis/crypto/test_c019/test_c019.c
+++ b/api-tests/dev_apis/crypto/test_c019/test_c019.c
@@ -89,7 +89,12 @@ int32_t psa_key_derivation_key_agreement_test(caller_security_t caller __UNUSED)
         val->crypto_function(VAL_CRYPTO_RESET_KEY_ATTRIBUTES, &attributes);
 
         if (check1[i].expected_status != PSA_SUCCESS)
+        {
+            /* Destroy a key and restore the slot to its default state */
+            status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
+            TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
             continue;
+        }
 
         /* Destroy a key and restore the slot to its default state */
         status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);

--- a/api-tests/dev_apis/crypto/test_c021/test_c021.c
+++ b/api-tests/dev_apis/crypto/test_c021/test_c021.c
@@ -154,6 +154,13 @@ int32_t psa_key_derivation_output_key_test(caller_security_t caller __UNUSED)
         TEST_ASSERT_DUAL(status, check1[i].expected_status[0], check1[i].expected_status[1],\
                          TEST_CHECKPOINT_NUM(14));
 
+        if ((check1[i].expected_status[0] == PSA_SUCCESS) &&
+            (check1[i].expected_status[1] == PSA_SUCCESS))
+            {
+                status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, keys[SLOT_1]);
+                TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(20));
+
+            }
         {
             status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(15));


### PR DESCRIPTION
Dear maintainers,

While running the psa-arch-tests crypto testsuite, I came to the conclusion that certain key material builds up in the test suite and does not get destroyed. This is fine for SPE's with enough key storage.

In my case I have a limited key storage (2 slots) due to RAM constraints. 

The changes in this pull request aim to destroy any key-material as soon as it's not needed anymore, as to prevent unused key slots keep being reserved.

Reading through the PSA Crypto API Version 1.1.0 spec, I couldn't find any mention of a minimum amount of volatile keys that need to be supported, if there is such an amount, please let me know. However, I do think that all key material should have been destroyed at the end of each testcase, and this PR tries to achieve that.

This is my first pull request, let me know if I break some PR etiquette, or if something is unclear.

Regards,
Evert
evert.van.rossum@qorvo.com 