### PR TITLE
Enable custom test list

### DIFF
--- a/api-tests/CMakeLists.txt
+++ b/api-tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 #/** @file
 # * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
+# * Copyright 2023 NXP
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -647,6 +648,7 @@ if(${CC312_LEGACY_DRIVER_API_ENABLED})
 endif()
 
 # Build PAL NSPE LIB
+include(${PSA_ROOT_DIR}/platform/targets/common/nspe/pal_nspe.cmake)
 include(${PSA_ROOT_DIR}/platform/targets/${TARGET}/target.cmake)
 # Build VAL NSPE LIB
 #add_definitions(-DVAL_NSPE_BUILD)

--- a/api-tests/docs/porting_guide_dev_apis.md
+++ b/api-tests/docs/porting_guide_dev_apis.md
@@ -66,6 +66,8 @@ Since the test suite is agnostic to various system targets, you must port the fo
 | 12 | uint32_t pal_compute_hash(int32_t cose_alg_id, struct q_useful_buf buffer_for_hash, struct q_useful_buf_c *hash, struct q_useful_buf_c protected_headers, struct q_useful_buf_c payload);                                                                | Computes hash for the requested data                       | cose_alg_id    : Algorithm ID<br/>buffer_for_hash  : Temp buffer for calculating hash<br/><br/>hash  : Pointer to store the hash<br/> buffer_for_hash  : Temp buffer for calculating hash<br/>protected_headers : data to be hashed<br/>payload  : Payload data<br/>                             |
 | 13 | uint32_t pal_crypto_pub_key_verify(int32_t cose_algorithm_id, struct q_useful_buf_c token_hash, struct q_useful_buf_c signature);                                                                | Function call to verify the signature using the public key              | cose_algorithm_id    : Algorithm ID<br/>token_hash  : Data that needs to be verified<br/>signature  : Signature to be verified against<br/>                             |
 | 14 | int pal_system_reset(void) | Resets the system | None |
+| 15 | pal_set_custom_test_list(char *custom_test_list); | Sets the custom test list buffer | custom_test_list : Custom test list buffer<br/>                             |
+| 16 | pal_is_test_enabled(test_id_t test_id); | Tells if a test is enabled on platform | test_id : Test ID<br/>                             |
 
 ## License
 Arm PSA test suite is distributed under Apache v2.0 License.

--- a/api-tests/platform/targets/common/nspe/pal_nspe.cmake
+++ b/api-tests/platform/targets/common/nspe/pal_nspe.cmake
@@ -1,0 +1,21 @@
+#/** @file
+# * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+# * Copyright 2023 NXP
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *  http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#**/
+
+# PAL C source files part of NSPE library
+list(APPEND PAL_SRC_C_NSPE
+	${PSA_ROOT_DIR}/platform/targets/common/nspe/pal_weak.c)

--- a/api-tests/platform/targets/common/nspe/pal_weak.c
+++ b/api-tests/platform/targets/common/nspe/pal_weak.c
@@ -1,0 +1,34 @@
+/** @file
+ * Copyright (c) 2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright 2023 NXP
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+
+__attribute__((weak)) void pal_set_custom_test_list(char *custom_test_list)
+{
+	(void)custom_test_list;
+
+	return;
+}
+
+__attribute__((weak)) bool_t pal_is_test_enabled(test_id_t test_id)
+{
+	(void)test_id;
+
+	return 1;
+}
+

--- a/api-tests/platform/targets/tgt_dev_apis_linux/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_linux/nspe/pal_driver_intf.c
@@ -1,5 +1,6 @@
 /** @file
  * Copyright (c) 2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright 2023 NXP
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,6 +38,15 @@
 
 #define NVMEM_SIZE (1024)
 static uint8_t g_nvmem[NVMEM_SIZE];
+
+/* The custom test list is a buffer in which all enabled test names are concatenated.
+ * The test name template is <TEST_NAME_PREFIX><id><TEST_NAME_SUFFIX>, where <id>
+ * is the test identifier.
+ */
+#define TEST_NAME_PREFIX "test_"
+#define TEST_NAME_SUFFIX ";"
+
+char *g_custom_test_list = NULL;
 
 /**
     @brief    - Check that an nvmem access is within the bounds of the nvmem
@@ -197,4 +207,32 @@ void pal_terminate_simulation(void)
 int pal_system_reset(void)
 {
     return PAL_STATUS_UNSUPPORTED_FUNC;
+}
+
+/**
+ *   @brief    - Sets the custom test list buffer
+ *   @param    - custom_test_list : Custom test list buffer 
+     @return   - void
+**/
+void pal_set_custom_test_list(char *custom_test_list)
+{
+    g_custom_test_list = custom_test_list;
+}
+
+/**
+ *   @brief    - Tells if a test is enabled on platform
+ *   @param    - test_id : Test ID
+ *   @return   - TRUE/FALSE
+**/
+bool_t pal_is_test_enabled(test_id_t test_id)
+{
+    char test_id_str[16] = { 0 };
+
+    if (!g_custom_test_list)
+        return 1;
+
+    if (sprintf(test_id_str, "%s%d%s", TEST_NAME_PREFIX, test_id, TEST_NAME_SUFFIX) <= 0)
+        return 0;
+
+    return strstr(g_custom_test_list, test_id_str)?1:0;
 }

--- a/api-tests/val/nspe/pal_interfaces_ns.h
+++ b/api-tests/val/nspe/pal_interfaces_ns.h
@@ -1,5 +1,6 @@
 /** @file
  * Copyright (c) 2018-2020, Arm Limited or its affiliates. All rights reserved.
+ * Copyright 2023 NXP
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,4 +127,18 @@ void pal_terminate_simulation(void);
  *   @return   - SUCCESS/FAILURE
 **/
 int pal_system_reset(void);
+
+/**
+ *   @brief    - Sets the custom test list buffer
+ *   @param    - custom_test_list : Custom test list buffer 
+     @return   - void
+**/
+void pal_set_custom_test_list(char *custom_test_list);
+
+/**
+ *   @brief    - Tells if a test is enabled on platform
+ *   @param    - test_id : Test ID
+ *   @return   - TRUE/FALSE
+**/
+bool_t pal_is_test_enabled(test_id_t test_id);
 #endif

--- a/api-tests/val/nspe/val_dispatcher.c
+++ b/api-tests/val/nspe/val_dispatcher.c
@@ -89,7 +89,7 @@ val_status_t val_test_load(test_id_t *test_id, test_id_t test_id_prev)
 
     for(; test_info->test_id != VAL_INVALID_TEST_ID; test_info++)
     {
-        if (pal_is_test_enabled(VAL_GET_TEST_NUM(test_info->test_id)))
+        if (pal_is_test_enabled(test_info->test_id))
         {
             *test_id = test_info->test_id;
             g_test_info_addr = (addr_t) test_info->entry_addr;

--- a/api-tests/val/nspe/val_dispatcher.c
+++ b/api-tests/val/nspe/val_dispatcher.c
@@ -60,6 +60,42 @@ __attribute__((unused)) static void val_print_api_version(void)
 #endif
 }
 
+static val_test_info_t g_test_list[] = {
+#include "test_entry_list.inc"
+                                  {VAL_INVALID_TEST_ID, NULL}
+                              };
+
+/**
+    @brief        - This function returns the IDs list of available tests
+    @param        - test_id_list : Buffer allocated by caller
+                  - size : Size of test_id_list
+    @return       - If test_id_list is NULL, the required size of test_id_list
+                    else if size is too small -1 
+                    else the actual size of test_id_list
+**/
+size_t val_get_test_list(uint32_t *test_id_list, size_t size)
+{
+
+    val_test_info_t *test_info = &g_test_list[0];
+    size_t test_list_size = sizeof(g_test_list)/sizeof(g_test_list[0]) - 1;
+
+    if (!test_id_list)
+        return test_list_size;
+
+    if (size < test_list_size)
+        return -1;
+
+    test_list_size = 0;
+
+    for(; test_info->test_id != VAL_INVALID_TEST_ID; test_info++)
+    {
+        *test_id_list++ = test_info->test_id;
+        test_list_size++;
+    }
+
+    return test_list_size;
+}
+
 /**
     @brief        - This function reads the test ELFs from RAM or secondary storage and loads into
                     system memory
@@ -69,11 +105,7 @@ __attribute__((unused)) static void val_print_api_version(void)
 **/
 val_status_t val_test_load(test_id_t *test_id, test_id_t test_id_prev)
 {
-    val_test_info_t test_list[] = {
-#include "test_entry_list.inc"
-                                  {VAL_INVALID_TEST_ID, NULL}
-                                  };
-    val_test_info_t *test_info = &test_list[0];
+    val_test_info_t *test_info = &g_test_list[0];
 
     if (test_id_prev != VAL_INVALID_TEST_ID)
     {


### PR DESCRIPTION
**Context**
As the list of test cases is built at compile time, if some test cases need to be disabled, custom NSPE binaries and a custom test executable need to be built.
This is the case when
- the test suite does not match the capabilities of the implementation
- the implementation and the test suite are incompatible (updated the test suite or implementation under development)

**Improvement**
Implement a mechanism to customize the list of test cases at runtime.
This mechanism defines the list of runable test cases among the list of test cases implemented by the test suite.
Using this mechanism, generic NSPE binaries can be used for platforms with different capabilities.

**This PR**
Added 2 PAL functions:
pal_set_custom_test_list() - Sets the custom test list buffer
pal_is_test_enabled() - Tells if a test is enabled on platform

A platform can provide the custom test case list by calling pal_set_custom_test_list().
The Validation Abstraction Layer (VAL) calls pal_is_test_enabled() to check if a test case is enabled and eventually runs it.
All test cases are enabled if no custom list of test cases is provided.
Platforms that do not need to implement this mechanism do not have to implement these 2 PAL functions.

**To reviewers**
Please feel free to propose any change you may find relevant. I will update the PR accordingly.