### PR TITLE
dev_apis: make "const" test_data check1

### DIFF
--- a/api-tests/dev_apis/initial_attestation/test_a001/test_a001.c
+++ b/api-tests/dev_apis/initial_attestation/test_a001/test_a001.c
@@ -39,6 +39,8 @@ int32_t psa_initial_attestation_get_token_test(caller_security_t caller __UNUSED
 
     for (i = 0; i < num_checks; i++)
     {
+        size_t                  challenge_size = check1[i].challenge_size;
+
         val->print(PRINT_TEST, "[Check %d] ", g_test_count++);
         val->print(PRINT_TEST, check1[i].test_desc, 0);
 
@@ -46,15 +48,15 @@ int32_t psa_initial_attestation_get_token_test(caller_security_t caller __UNUSED
         memset(token_buffer, 0, sizeof(token_buffer));
 
         status = val->attestation_function(VAL_INITIAL_ATTEST_GET_TOKEN_SIZE,
-                     check1[i].challenge_size, &token_buffer_size);
+                     challenge_size, &token_buffer_size);
         if (status != PSA_SUCCESS)
         {
-            if (check1[i].challenge_size != PSA_INITIAL_ATTEST_CHALLENGE_SIZE_32 ||
-                check1[i].challenge_size != PSA_INITIAL_ATTEST_CHALLENGE_SIZE_48 ||
-                check1[i].challenge_size != PSA_INITIAL_ATTEST_CHALLENGE_SIZE_64)
+            if (challenge_size != PSA_INITIAL_ATTEST_CHALLENGE_SIZE_32 ||
+                challenge_size != PSA_INITIAL_ATTEST_CHALLENGE_SIZE_48 ||
+                challenge_size != PSA_INITIAL_ATTEST_CHALLENGE_SIZE_64)
             {
                 token_buffer_size = check1[i].token_size;
-                check1[i].challenge_size = check1[i].actual_challenge_size;
+                challenge_size = check1[i].actual_challenge_size;
             }
             else
                 return status;
@@ -67,7 +69,7 @@ int32_t psa_initial_attestation_get_token_test(caller_security_t caller __UNUSED
         }
 
         status = val->attestation_function(VAL_INITIAL_ATTEST_GET_TOKEN, challenge,
-                     check1[i].challenge_size, token_buffer, token_buffer_size, &token_size);
+                     challenge_size, token_buffer, token_buffer_size, &token_size);
         TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(1));
 
         if (check1[i].expected_status != PSA_SUCCESS)
@@ -75,7 +77,7 @@ int32_t psa_initial_attestation_get_token_test(caller_security_t caller __UNUSED
 
         /* Validate the token */
         status = val->attestation_function(VAL_INITIAL_ATTEST_VERIFY_TOKEN, challenge,
-                    check1[i].challenge_size, token_buffer, token_size);
+                    challenge_size, token_buffer, token_size);
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(2));
     }
 

--- a/api-tests/dev_apis/initial_attestation/test_a001/test_data.h
+++ b/api-tests/dev_apis/initial_attestation/test_a001/test_data.h
@@ -26,7 +26,7 @@ typedef struct {
 } test_data;
 
 
-static test_data check1[] = {
+static const test_data check1[] = {
 {"Test psa_initial_attestation_get_token with Challenge 32\n",
  PSA_INITIAL_ATTEST_CHALLENGE_SIZE_32, PSA_INITIAL_ATTEST_CHALLENGE_SIZE_32, TOKEN_SIZE, PSA_SUCCESS
 },


### PR DESCRIPTION
Make "const" test data of the initial attestation test. It saves valuable amount of RAM.