### PR TITLE
crypto: Avoid static buffer allocation.

### DIFF
--- a/api-tests/dev_apis/crypto/test_c043/test_c043.c
+++ b/api-tests/dev_apis/crypto/test_c043/test_c043.c
@@ -29,10 +29,9 @@ const client_test_t test_c043_crypto_list[] = {
 
 extern  uint32_t g_test_count;
 
-static uint8_t     output[SIZE_50B];
-
 int32_t psa_raw_key_agreement_test(caller_security_t caller __UNUSED)
 {
+    uint8_t                 output[SIZE_50B];
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
     size_t                  output_length;
@@ -97,6 +96,7 @@ int32_t psa_raw_key_agreement_test(caller_security_t caller __UNUSED)
 int32_t psa_raw_key_agreement_negative_test(caller_security_t caller __UNUSED)
 {
 #if defined(ARCH_TEST_ECDH) && defined(ARCH_TEST_ECC_CURVE_SECP256R1)
+    uint8_t                 output[SIZE_50B];
     int                     num_checks = sizeof(check2)/sizeof(check2[0]);
     int32_t                 i, status;
     size_t                  output_length;

--- a/api-tests/dev_apis/crypto/test_c046/test_c046.c
+++ b/api-tests/dev_apis/crypto/test_c046/test_c046.c
@@ -28,10 +28,9 @@ const client_test_t test_c046_crypto_list[] = {
 
 extern  uint32_t g_test_count;
 
-static uint8_t       data[BUFFER_SIZE];
-
 int32_t psa_mac_compute_test(caller_security_t caller __UNUSED)
 {
+    uint8_t               data[BUFFER_SIZE];
     int                   num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t               i, status;
     size_t                length;

--- a/api-tests/dev_apis/crypto/test_c048/test_c048.c
+++ b/api-tests/dev_apis/crypto/test_c048/test_c048.c
@@ -28,12 +28,12 @@ const client_test_t test_c048_crypto_list[] = {
 
 extern  uint32_t g_test_count;
 
-static uint8_t    output[64];
-
 int32_t psa_cipher_encrypt_test(caller_security_t caller __UNUSED)
 {
 #if ((defined(ARCH_TEST_AES_128) && (defined(ARCH_TEST_CBC_NO_PADDING) || defined(ARCH_TEST_CBC_PKCS7) || defined(ARCH_TEST_CIPHER_MODE_CTR)))||\
 (defined(ARCH_TEST_CBC_NO_PADDING) && (defined(ARCH_TEST_DES_1KEY) || defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY))))
+
+    uint8_t                 output[64];
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
     size_t                  output_length;

--- a/api-tests/dev_apis/crypto/test_c049/test_c049.c
+++ b/api-tests/dev_apis/crypto/test_c049/test_c049.c
@@ -28,12 +28,11 @@ const client_test_t test_c049_crypto_list[] = {
 
 extern  uint32_t g_test_count;
 
-static uint8_t    output[SIZE_32B];
-
 int32_t psa_cipher_decrypt_test(caller_security_t caller __UNUSED)
 {
 #if ((defined(ARCH_TEST_AES_128) && (defined(ARCH_TEST_CBC_NO_PADDING) || defined(ARCH_TEST_CBC_PKCS7) || defined(ARCH_TEST_CIPHER_MODE_CTR)))||\
 (defined(ARCH_TEST_CBC_NO_PADDING) && (defined(ARCH_TEST_DES_1KEY) || defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY))))
+    uint8_t                 output[SIZE_32B];
     int                     num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
     size_t                  output_length;

--- a/api-tests/dev_apis/crypto/test_c059/test_c059.c
+++ b/api-tests/dev_apis/crypto/test_c059/test_c059.c
@@ -27,11 +27,12 @@ const client_test_t test_c059_crypto_list[] = {
 };
 
 extern  uint32_t g_test_count;
-static uint8_t  output[BUFFER_SIZE], tag[SIZE_128B];
 
 int32_t psa_aead_finish_test(caller_security_t caller __UNUSED)
 {
 #if ((defined(ARCH_TEST_CCM) || defined(ARCH_TEST_GCM)) && defined(ARCH_TEST_AES_128)) 
+    uint8_t               output[BUFFER_SIZE];
+    uint8_t               tag[SIZE_128B];
     int32_t               i, status;
     size_t                length, finish_length, tag_length;
     int                   num_checks = sizeof(check1)/sizeof(check1[0]);

--- a/api-tests/dev_apis/crypto/test_c061/test_c061.c
+++ b/api-tests/dev_apis/crypto/test_c061/test_c061.c
@@ -27,11 +27,11 @@ const client_test_t test_c061_crypto_list[] = {
 };
 
 extern  uint32_t g_test_count;
-static uint8_t  output[BUFFER_SIZE];
 
 int32_t psa_aead_verify_test(caller_security_t caller __UNUSED)
 {
 #if ((defined(ARCH_TEST_CCM) || defined(ARCH_TEST_GCM)) && defined(ARCH_TEST_AES_128))
+    uint8_t               output[BUFFER_SIZE]; //NXP
     int32_t               i, status;
     size_t                length, verify_length;
     int                   num_checks = sizeof(check1)/sizeof(check1[0]);


### PR DESCRIPTION
- Use shared stack instead of static buffer allocation.
- Save several KBs of RAM.