### PR TITLE
pal: val: Set input parameter as const for nvmem_write()

### DIFF
--- a/api-tests/val/nspe/pal_interfaces_ns.h
+++ b/api-tests/val/nspe/pal_interfaces_ns.h
@@ -79,7 +79,7 @@ int pal_nvmem_read_ns(addr_t base, uint32_t offset, void *buffer, int size);
  *               size    : Number of bytes
  *   @return   - SUCCESS/FAILURE
 **/
-int pal_nvmem_write_ns(addr_t base, uint32_t offset, void *buffer, int size);
+int pal_nvmem_write_ns(addr_t base, uint32_t offset, const void *buffer, int size);
 
 /**
  *   @brief    - This API will call the requested crypto function

--- a/api-tests/val/nspe/val_interfaces.h
+++ b/api-tests/val/nspe/val_interfaces.h
@@ -50,7 +50,7 @@ typedef struct {
     void             (*ipc_close)                 (psa_handle_t handle);
     val_status_t     (*get_secure_test_result)    (psa_handle_t *handle);
     val_status_t     (*nvmem_read)                (uint32_t offset, void *buffer, int size);
-    val_status_t     (*nvmem_write)               (uint32_t offset, void *buffer, int size);
+    val_status_t     (*nvmem_write)               (uint32_t offset, const void *buffer, int size);
     val_status_t     (*wd_timer_init)             (wd_timeout_type_t timeout_type);
     val_status_t     (*wd_timer_enable)           (void);
     val_status_t     (*wd_timer_disable)          (void);

--- a/api-tests/val/nspe/val_peripherals.c
+++ b/api-tests/val/nspe/val_peripherals.c
@@ -217,7 +217,7 @@ val_status_t val_nvmem_read(uint32_t offset, void *buffer, int size)
                - size      : Number of bytes
     @return    - val_status_t
 */
-val_status_t val_nvmem_write(uint32_t offset, void *buffer, int size)
+val_status_t val_nvmem_write(uint32_t offset, const void *buffer, int size)
 {
    memory_desc_t   *memory_desc;
    val_status_t    status = VAL_STATUS_SUCCESS;

--- a/api-tests/val/nspe/val_peripherals.h
+++ b/api-tests/val/nspe/val_peripherals.h
@@ -23,7 +23,7 @@
 val_status_t val_uart_init(void);
 val_status_t val_print(print_verbosity_t verbosity, const char *string, int32_t data);
 val_status_t val_nvmem_read(uint32_t offset, void *buffer, int size);
-val_status_t val_nvmem_write(uint32_t offset, void *buffer, int size);
+val_status_t val_nvmem_write(uint32_t offset, const void *buffer, int size);
 val_status_t val_wd_timer_init(wd_timeout_type_t timeout_type);
 val_status_t val_wd_timer_enable(void);
 val_status_t val_wd_timer_disable(void);


### PR DESCRIPTION
- Apply the rule "use const for function parameters passed by reference where the function does not modify the data pointed to".
- Avoid possible compilation warnings/errors and type casting.