### PR TITLE
crypto: add ifndef to MIN and MAX macros

### DIFF
--- a/api-tests/dev_apis/crypto/common/test_crypto_common.h
+++ b/api-tests/dev_apis/crypto/common/test_crypto_common.h
@@ -41,8 +41,12 @@
 #define PSA_ERROR_PROGRAMMER_ERROR      ((psa_status_t)-129)
 
 /* min and max finding macro */
+#ifndef MIN
 #define MIN(a, b) (((a) < (b))?(a):(b))
+#endif
+#ifndef MAX
 #define MAX(a, b) (((a) > (b))?(a):(b))
+#endif
 
 extern const uint8_t key_data[];
 


### PR DESCRIPTION
Add the #ifndef protection for MIN and MAX macros, to avoid possible compilation error/warning
if definitions are defined in a common header of used environment. 
The issues is valid for NXP MCUx SDK.