### PR TITLE
attest: Use PSA_ALG_MD5 by default

### DIFF
--- a/api-tests/platform/targets/common/nspe/initial_attestation/pal_attestation_crypto.c
+++ b/api-tests/platform/targets/common/nspe/initial_attestation/pal_attestation_crypto.c
@@ -17,11 +17,6 @@
 
 #include "pal_attestation_crypto.h"
 
-/* this macro is missing from the psa_crypto.h file
- * this can be removed once the TFM fix available
- */
-#define PSA_ALG_MD4 ((psa_algorithm_t)0x02000002)
-
 static uint32_t         public_key_registered;
 static psa_key_handle_t public_key_handle;
 
@@ -41,7 +36,7 @@ static psa_algorithm_t cose_hash_alg_id_to_psa(int32_t cose_hash_alg_id)
         status = PSA_ALG_SHA_256;
         break;
     default:
-        status = PSA_ALG_MD4;
+        status = PSA_ALG_MD5;
         break;
     }
 


### PR DESCRIPTION
- Use PSA_ALG_MD5 by default, instead of PSA_ALG_MD4.
- Avoid PSA_ALG_MD4 workaround definition, not supported by TFM/MbedTLS.