### PR TITLE
Fix base address for the nrf watchdog

### DIFF
--- a/api-tests/platform/drivers/watchdog/nrf/nrf_wdt.c
+++ b/api-tests/platform/drivers/watchdog/nrf/nrf_wdt.c
@@ -33,7 +33,7 @@
  * of relying on the target configuration system.
  */
 #define NRF_WDT31_NS ((struct NRF_WDT_Type *)0x40109000)
-#define NRF_WDT0_NS ((struct NRF_WDT_Type *)0x50018000)
+#define NRF_WDT0_NS ((struct NRF_WDT_Type *)0x40018000)
 
 #ifdef NRF54L15_ENGA_XXAA
 #define PSA_TEST_WDT_INSTANCE NRF_WDT31_NS


### PR DESCRIPTION
Fix base address for the nrf watchdog.

Testing shows that it should be 0x4, not 0x5.