### PR TITLE
Added test vectors with AES in CBC mode

### DIFF
--- a/api-tests/dev_apis/crypto/test_c003/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c003/test_data.h
@@ -78,6 +78,53 @@ static const test_data check1[] = {
 #endif
 #endif
 
+#ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc            = "Test psa_export_key 16 Byte AES\n",
+    .type                 = PSA_KEY_TYPE_AES,
+    .data                 = key_data,
+    .data_length          = AES_16B_KEY_SIZE,
+    .bits                 = BYTES_TO_BITS(AES_16B_KEY_SIZE),
+    .usage_flags          = PSA_KEY_USAGE_EXPORT,
+    .expected_data        = expected_output,
+    .data_size            = BUFFER_SIZE,
+    .expected_data_length = AES_16B_KEY_SIZE,
+    .expected_status      = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_192
+{
+    .test_desc            = "Test psa_export_key 24 Byte AES\n",
+    .type                 = PSA_KEY_TYPE_AES,
+    .data                 = key_data,
+    .data_length          = AES_24B_KEY_SIZE,
+    .bits                 = BYTES_TO_BITS(AES_24B_KEY_SIZE),
+    .usage_flags          = PSA_KEY_USAGE_EXPORT,
+    .expected_data        = expected_output,
+    .data_size            = BUFFER_SIZE,
+    .expected_data_length = AES_24B_KEY_SIZE,
+    .expected_status      = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_256
+{
+    .test_desc            = "Test psa_export_key 32 Byte AES\n",
+    .type                 = PSA_KEY_TYPE_AES,
+    .data                 = key_data,
+    .data_length          = AES_32B_KEY_SIZE,
+    .bits                 = BYTES_TO_BITS(AES_32B_KEY_SIZE),
+    .usage_flags          = PSA_KEY_USAGE_EXPORT,
+    .expected_data        = expected_output,
+    .data_size            = BUFFER_SIZE,
+    .expected_data_length = AES_32B_KEY_SIZE,
+    .expected_status      = PSA_SUCCESS
+},
+#endif
+#endif
+
 #ifdef ARCH_TEST_RSA_PKCS1V15_SIGN_RAW
 #ifdef ARCH_TEST_RSA_2048
 {

--- a/api-tests/dev_apis/crypto/test_c003/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c003/test_data.h
@@ -78,7 +78,7 @@ static const test_data check1[] = {
 #endif
 #endif
 
-#ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_CIPHER_MODE_CBC
 #ifdef ARCH_TEST_AES_128
 {
     .test_desc            = "Test psa_export_key 16 Byte AES\n",

--- a/api-tests/dev_apis/crypto/test_c003/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c003/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,54 +31,7 @@ typedef struct {
 } test_data;
 
 static const test_data check1[] = {
-#ifdef ARCH_TEST_CIPHER_MODE_CTR
-#ifdef ARCH_TEST_AES_128
-{
-    .test_desc            = "Test psa_export_key 16 Byte AES\n",
-    .type                 = PSA_KEY_TYPE_AES,
-    .data                 = key_data,
-    .data_length          = AES_16B_KEY_SIZE,
-    .bits                 = BYTES_TO_BITS(AES_16B_KEY_SIZE),
-    .usage_flags          = PSA_KEY_USAGE_EXPORT,
-    .expected_data        = expected_output,
-    .data_size            = BUFFER_SIZE,
-    .expected_data_length = AES_16B_KEY_SIZE,
-    .expected_status      = PSA_SUCCESS
-},
-#endif
-
-#ifdef ARCH_TEST_AES_192
-{
-    .test_desc            = "Test psa_export_key 24 Byte AES\n",
-    .type                 = PSA_KEY_TYPE_AES,
-    .data                 = key_data,
-    .data_length          = AES_24B_KEY_SIZE,
-    .bits                 = BYTES_TO_BITS(AES_24B_KEY_SIZE),
-    .usage_flags          = PSA_KEY_USAGE_EXPORT,
-    .expected_data        = expected_output,
-    .data_size            = BUFFER_SIZE,
-    .expected_data_length = AES_24B_KEY_SIZE,
-    .expected_status      = PSA_SUCCESS
-},
-#endif
-
-#ifdef ARCH_TEST_AES_256
-{
-    .test_desc            = "Test psa_export_key 32 Byte AES\n",
-    .type                 = PSA_KEY_TYPE_AES,
-    .data                 = key_data,
-    .data_length          = AES_32B_KEY_SIZE,
-    .bits                 = BYTES_TO_BITS(AES_32B_KEY_SIZE),
-    .usage_flags          = PSA_KEY_USAGE_EXPORT,
-    .expected_data        = expected_output,
-    .data_size            = BUFFER_SIZE,
-    .expected_data_length = AES_32B_KEY_SIZE,
-    .expected_status      = PSA_SUCCESS
-},
-#endif
-#endif
-
-#ifdef ARCH_TEST_CIPHER_MODE_CBC
+#if defined(ARCH_TEST_CIPHER_MODE_CTR) || defined(ARCH_TEST_CIPHER_MODE_CBC)
 #ifdef ARCH_TEST_AES_128
 {
     .test_desc            = "Test psa_export_key 16 Byte AES\n",

--- a/api-tests/dev_apis/crypto/test_c004/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c004/test_data.h
@@ -110,6 +110,53 @@ static const test_data check1[] = {
 #endif
 #endif
 
+#ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc            = "Test psa_export_public_key 16 Byte AES\n",
+    .type                 = PSA_KEY_TYPE_AES,
+    .data                 = key_data,
+    .data_length          = AES_16B_KEY_SIZE,
+    .bits                 = BYTES_TO_BITS(AES_16B_KEY_SIZE),
+    .usage_flags          = PSA_KEY_USAGE_EXPORT,
+    .expected_data        = expected_output,
+    .data_size            = BUFFER_SIZE,
+    .expected_data_length = AES_16B_KEY_SIZE,
+    .expected_status      = PSA_ERROR_INVALID_ARGUMENT
+},
+#endif
+
+#ifdef ARCH_TEST_AES_192
+{
+    .test_desc            = "Test psa_export_public_key 24 Byte AES\n",
+    .type                 = PSA_KEY_TYPE_AES,
+    .data                 = key_data,
+    .data_length          = AES_24B_KEY_SIZE,
+    .bits                 = BYTES_TO_BITS(AES_24B_KEY_SIZE),
+    .usage_flags          = PSA_KEY_USAGE_EXPORT,
+    .expected_data        = expected_output,
+    .data_size            = BUFFER_SIZE,
+    .expected_data_length = AES_24B_KEY_SIZE,
+    .expected_status      = PSA_ERROR_INVALID_ARGUMENT
+},
+#endif
+
+#ifdef ARCH_TEST_AES_256
+{
+    .test_desc            = "Test psa_export_public_key 32 Byte AES\n",
+    .type                 = PSA_KEY_TYPE_AES,
+    .data                 = key_data,
+    .data_length          = AES_32B_KEY_SIZE,
+    .bits                 = BYTES_TO_BITS(AES_32B_KEY_SIZE),
+    .usage_flags          = PSA_KEY_USAGE_EXPORT,
+    .expected_data        = expected_output,
+    .data_size            = BUFFER_SIZE,
+    .expected_data_length = AES_32B_KEY_SIZE,
+    .expected_status      = PSA_ERROR_INVALID_ARGUMENT
+},
+#endif
+#endif
+
 #ifdef ARCH_TEST_RSA_PKCS1V15_SIGN_RAW
 #ifdef ARCH_TEST_RSA_2048
 {

--- a/api-tests/dev_apis/crypto/test_c004/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c004/test_data.h
@@ -110,7 +110,7 @@ static const test_data check1[] = {
 #endif
 #endif
 
-#ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_CIPHER_MODE_CBC
 #ifdef ARCH_TEST_AES_128
 {
     .test_desc            = "Test psa_export_public_key 16 Byte AES\n",

--- a/api-tests/dev_apis/crypto/test_c004/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c004/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2018-2021, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,54 +63,7 @@ static const uint8_t expected_ec_pubprv[] = {
 
 static const test_data check1[] = {
 
-#ifdef ARCH_TEST_CIPHER_MODE_CTR
-#ifdef ARCH_TEST_AES_128
-{
-    .test_desc            = "Test psa_export_public_key 16 Byte AES\n",
-    .type                 = PSA_KEY_TYPE_AES,
-    .data                 = key_data,
-    .data_length          = AES_16B_KEY_SIZE,
-    .bits                 = BYTES_TO_BITS(AES_16B_KEY_SIZE),
-    .usage_flags          = PSA_KEY_USAGE_EXPORT,
-    .expected_data        = expected_output,
-    .data_size            = BUFFER_SIZE,
-    .expected_data_length = AES_16B_KEY_SIZE,
-    .expected_status      = PSA_ERROR_INVALID_ARGUMENT
-},
-#endif
-
-#ifdef ARCH_TEST_AES_192
-{
-    .test_desc            = "Test psa_export_public_key 24 Byte AES\n",
-    .type                 = PSA_KEY_TYPE_AES,
-    .data                 = key_data,
-    .data_length          = AES_24B_KEY_SIZE,
-    .bits                 = BYTES_TO_BITS(AES_24B_KEY_SIZE),
-    .usage_flags          = PSA_KEY_USAGE_EXPORT,
-    .expected_data        = expected_output,
-    .data_size            = BUFFER_SIZE,
-    .expected_data_length = AES_24B_KEY_SIZE,
-    .expected_status      = PSA_ERROR_INVALID_ARGUMENT
-},
-#endif
-
-#ifdef ARCH_TEST_AES_256
-{
-    .test_desc            = "Test psa_export_public_key 32 Byte AES\n",
-    .type                 = PSA_KEY_TYPE_AES,
-    .data                 = key_data,
-    .data_length          = AES_32B_KEY_SIZE,
-    .bits                 = BYTES_TO_BITS(AES_32B_KEY_SIZE),
-    .usage_flags          = PSA_KEY_USAGE_EXPORT,
-    .expected_data        = expected_output,
-    .data_size            = BUFFER_SIZE,
-    .expected_data_length = AES_32B_KEY_SIZE,
-    .expected_status      = PSA_ERROR_INVALID_ARGUMENT
-},
-#endif
-#endif
-
-#ifdef ARCH_TEST_CIPHER_MODE_CBC
+#if defined(ARCH_TEST_CIPHER_MODE_CTR) || defined(ARCH_TEST_CIPHER_MODE_CBC)
 #ifdef ARCH_TEST_AES_128
 {
     .test_desc            = "Test psa_export_public_key 16 Byte AES\n",

--- a/api-tests/dev_apis/crypto/test_c018/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c018/test_data.h
@@ -17,6 +17,12 @@
 
 #include "test_crypto_common.h"
 
+#ifdef ARCH_TEST_HKDF_FAILING_ALG
+#define HKDF_FAILING_ALG ARCH_TEST_HKDF_FAILING_ALG
+#else
+#define HKDF_FAILING_ALG PSA_ALG_CTR
+#endif
+
 typedef struct {
     char                        test_desc[75];
     psa_key_type_t              type;
@@ -132,7 +138,7 @@ static const test_data check1[] = {
     .data_length     = AES_32B_KEY_SIZE,
     .bits            = BYTES_TO_BITS(AES_32B_KEY_SIZE),
     .usage_flags     = PSA_KEY_USAGE_DERIVE,
-    .alg             = PSA_ALG_CTR,
+    .alg             = HKDF_FAILING_ALG,
     .step            = PSA_KEY_DERIVATION_INPUT_SECRET,
     .setup_alg       = PSA_ALG_HKDF(PSA_ALG_SHA_256),
     .expected_status = PSA_ERROR_NOT_PERMITTED

--- a/api-tests/dev_apis/crypto/test_c018/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c018/test_data.h
@@ -17,12 +17,6 @@
 
 #include "test_crypto_common.h"
 
-#ifdef ARCH_TEST_HKDF_FAILING_ALG
-#define HKDF_FAILING_ALG ARCH_TEST_HKDF_FAILING_ALG
-#else
-#define HKDF_FAILING_ALG PSA_ALG_CTR
-#endif
-
 typedef struct {
     char                        test_desc[75];
     psa_key_type_t              type;
@@ -138,7 +132,7 @@ static const test_data check1[] = {
     .data_length     = AES_32B_KEY_SIZE,
     .bits            = BYTES_TO_BITS(AES_32B_KEY_SIZE),
     .usage_flags     = PSA_KEY_USAGE_DERIVE,
-    .alg             = HKDF_FAILING_ALG,
+    .alg             = PSA_ALG_CBC_NO_PADDING,
     .step            = PSA_KEY_DERIVATION_INPUT_SECRET,
     .setup_alg       = PSA_ALG_HKDF(PSA_ALG_SHA_256),
     .expected_status = PSA_ERROR_NOT_PERMITTED

--- a/api-tests/dev_apis/crypto/test_c032/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c032/test_data.h
@@ -71,6 +71,45 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc       = "Test psa_cipher_encrypt_setup 16 Byte AES\n",
+    .type            = PSA_KEY_TYPE_AES,
+    .data            = key_data,
+    .data_length     = AES_16B_KEY_SIZE,
+    .bits            = BYTES_TO_BITS(AES_16B_KEY_SIZE),
+    .usage_flags     = PSA_KEY_USAGE_ENCRYPT,
+    .alg             = PSA_ALG_CBC_NO_PADDING,
+    .expected_status = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_192
+{
+    .test_desc       = "Test psa_cipher_encrypt_setup 24 Byte AES\n",
+    .type            = PSA_KEY_TYPE_AES,
+    .data            = key_data,
+    .data_length     = AES_24B_KEY_SIZE,
+    .bits            = BYTES_TO_BITS(AES_24B_KEY_SIZE),
+    .usage_flags     = PSA_KEY_USAGE_ENCRYPT,
+    .alg             = PSA_ALG_CBC_NO_PADDING,
+    .expected_status = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_256
+{
+    .test_desc       = "Test psa_cipher_encrypt_setup 32 Byte AES\n",
+    .type            = PSA_KEY_TYPE_AES,
+    .data            = key_data,
+    .data_length     = AES_32B_KEY_SIZE,
+    .bits            = BYTES_TO_BITS(AES_32B_KEY_SIZE),
+    .usage_flags     = PSA_KEY_USAGE_ENCRYPT,
+    .alg             = PSA_ALG_CBC_NO_PADDING,
+    .expected_status = PSA_SUCCESS
+},
+#endif
+
 #ifdef ARCH_TEST_DES_1KEY
 {
     .test_desc       = "Test psa_cipher_encrypt_setup DES 64 bit key\n",

--- a/api-tests/dev_apis/crypto/test_c032/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c032/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -73,7 +73,7 @@ static const test_data check1[] = {
 #ifdef ARCH_TEST_CBC_NO_PADDING
 #ifdef ARCH_TEST_AES_128
 {
-    .test_desc       = "Test psa_cipher_encrypt_setup 16 Byte AES\n",
+    .test_desc       = "Test psa_cipher_encrypt_setup 16 Byte AES in CBC mode\n",
     .type            = PSA_KEY_TYPE_AES,
     .data            = key_data,
     .data_length     = AES_16B_KEY_SIZE,
@@ -86,7 +86,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_192
 {
-    .test_desc       = "Test psa_cipher_encrypt_setup 24 Byte AES\n",
+    .test_desc       = "Test psa_cipher_encrypt_setup 24 Byte AES in CBC mode\n",
     .type            = PSA_KEY_TYPE_AES,
     .data            = key_data,
     .data_length     = AES_24B_KEY_SIZE,
@@ -99,7 +99,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_256
 {
-    .test_desc       = "Test psa_cipher_encrypt_setup 32 Byte AES\n",
+    .test_desc       = "Test psa_cipher_encrypt_setup 32 Byte AES in CBC mode\n",
     .type            = PSA_KEY_TYPE_AES,
     .data            = key_data,
     .data_length     = AES_32B_KEY_SIZE,

--- a/api-tests/dev_apis/crypto/test_c033/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c033/test_data.h
@@ -67,6 +67,42 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc       = "Test psa_cipher_decrypt_setup 16 Byte AES\n",
+    .type            = PSA_KEY_TYPE_AES,
+    .data            = key_data,
+    .data_length     = AES_16B_KEY_SIZE,
+    .usage_flags     = PSA_KEY_USAGE_DECRYPT,
+    .alg             = PSA_ALG_CBC_NO_PADDING,
+    .expected_status = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_192
+{
+    .test_desc       = "Test psa_cipher_decrypt_setup 24 Byte AES\n",
+    .type            = PSA_KEY_TYPE_AES,
+    .data            = key_data,
+    .data_length     = AES_24B_KEY_SIZE,
+    .usage_flags     = PSA_KEY_USAGE_DECRYPT,
+    .alg             = PSA_ALG_CBC_NO_PADDING,
+    .expected_status = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_256
+{
+    .test_desc       = "Test psa_cipher_decrypt_setup 32 Byte AES\n",
+    .type            = PSA_KEY_TYPE_AES,
+    .data            = key_data,
+    .data_length     = AES_32B_KEY_SIZE,
+    .usage_flags     = PSA_KEY_USAGE_DECRYPT,
+    .alg             = PSA_ALG_CBC_NO_PADDING,
+    .expected_status = PSA_SUCCESS
+},
+#endif
+
 #ifdef ARCH_TEST_DES_1KEY
 {
     .test_desc       = "Test psa_cipher_decrypt_setup DES 64 bit key\n",

--- a/api-tests/dev_apis/crypto/test_c033/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c033/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2022, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,7 @@ static const test_data check1[] = {
 #ifdef ARCH_TEST_CBC_NO_PADDING
 #ifdef ARCH_TEST_AES_128
 {
-    .test_desc       = "Test psa_cipher_decrypt_setup 16 Byte AES\n",
+    .test_desc       = "Test psa_cipher_decrypt_setup 16 Byte AES in CBC mode\n",
     .type            = PSA_KEY_TYPE_AES,
     .data            = key_data,
     .data_length     = AES_16B_KEY_SIZE,
@@ -81,7 +81,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_192
 {
-    .test_desc       = "Test psa_cipher_decrypt_setup 24 Byte AES\n",
+    .test_desc       = "Test psa_cipher_decrypt_setup 24 Byte AES in CBC mode\n",
     .type            = PSA_KEY_TYPE_AES,
     .data            = key_data,
     .data_length     = AES_24B_KEY_SIZE,
@@ -93,7 +93,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_256
 {
-    .test_desc       = "Test psa_cipher_decrypt_setup 32 Byte AES\n",
+    .test_desc       = "Test psa_cipher_decrypt_setup 32 Byte AES in CBC mode\n",
     .type            = PSA_KEY_TYPE_AES,
     .data            = key_data,
     .data_length     = AES_32B_KEY_SIZE,

--- a/api-tests/dev_apis/crypto/test_c034/test_c034.c
+++ b/api-tests/dev_apis/crypto/test_c034/test_c034.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api-tests/dev_apis/crypto/test_c034/test_c034.c
+++ b/api-tests/dev_apis/crypto/test_c034/test_c034.c
@@ -31,7 +31,9 @@ int32_t psa_cipher_generate_iv_test(caller_security_t caller __UNUSED)
 #if ((defined(ARCH_TEST_CIPHER_MODE_CTR) && (defined(ARCH_TEST_AES_128) || \
       defined(ARCH_TEST_AES_192) || defined(ARCH_TEST_AES_256))) || \
       (defined(ARCH_TEST_CBC_AES_NO_PADDING) && (defined(ARCH_TEST_DES_1KEY) || \
-       defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY))))
+       defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY) || \
+      defined(ARCH_TEST_AES_128) || defined(ARCH_TEST_AES_192) || \
+      defined(ARCH_TEST_AES_256))))
     int32_t                 i, num_checks = sizeof(check1)/sizeof(check1[0]);
     uint32_t                j, iv_sum;
     size_t                  expected_iv_length;

--- a/api-tests/dev_apis/crypto/test_c034/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c034/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,7 +87,7 @@ static const test_data check1[] = {
 #ifdef ARCH_TEST_CBC_NO_PADDING
 #ifdef ARCH_TEST_AES_128
 {
-    .test_desc          = "Test psa_cipher_generate_iv 16 Byte AES\n",
+    .test_desc          = "Test psa_cipher_generate_iv 16 Byte AES in CBC mode\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_16B_KEY_SIZE,
@@ -102,7 +102,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_192
 {
-    .test_desc          = "Test psa_cipher_generate_iv 24 Byte AES\n",
+    .test_desc          = "Test psa_cipher_generate_iv 24 Byte AES in CBC mode\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_24B_KEY_SIZE,
@@ -117,7 +117,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_256
 {
-    .test_desc          = "Test psa_cipher_generate_iv 32 Byte AES\n",
+    .test_desc          = "Test psa_cipher_generate_iv 32 Byte AES in CBC mode\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_32B_KEY_SIZE,

--- a/api-tests/dev_apis/crypto/test_c034/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c034/test_data.h
@@ -196,7 +196,7 @@ static const test_data check1[] = {
 #ifdef ARCH_TEST_CBC_NO_PADDING
 #ifdef ARCH_TEST_AES_128
 {
-    .test_desc          = "Test psa_cipher_generate_iv AES - small iv buffer\n",
+    .test_desc          = "Test psa_cipher_generate_iv AES in CBC mode - small iv buffer\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_16B_KEY_SIZE,

--- a/api-tests/dev_apis/crypto/test_c034/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c034/test_data.h
@@ -33,7 +33,9 @@ typedef struct {
 #if ((defined(ARCH_TEST_CIPHER_MODE_CTR) && (defined(ARCH_TEST_AES_128) || \
       defined(ARCH_TEST_AES_192) || defined(ARCH_TEST_AES_256))) || \
       (defined(ARCH_TEST_CBC_AES_NO_PADDING) && (defined(ARCH_TEST_DES_1KEY) || \
-      defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY))))
+      defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY) || \
+      defined(ARCH_TEST_AES_128) || defined(ARCH_TEST_AES_192) || \
+      defined(ARCH_TEST_AES_256))))
 static const test_data check1[] = {
 #ifdef ARCH_TEST_CIPHER_MODE_CTR
 #ifdef ARCH_TEST_AES_128
@@ -83,6 +85,51 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc          = "Test psa_cipher_generate_iv 16 Byte AES\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_16B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = expected_output,
+    .iv_size            = BUFFER_SIZE,
+    .expected_iv_length = 16,
+    .expected_status    = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_192
+{
+    .test_desc          = "Test psa_cipher_generate_iv 24 Byte AES\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_24B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = expected_output,
+    .iv_size            = BUFFER_SIZE,
+    .expected_iv_length = 16,
+    .expected_status    = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_256
+{
+    .test_desc          = "Test psa_cipher_generate_iv 32 Byte AES\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_32B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = expected_output,
+    .iv_size            = BUFFER_SIZE,
+    .expected_iv_length = 16,
+    .expected_status    = PSA_SUCCESS
+},
+#endif
+
 #ifdef ARCH_TEST_DES_1KEY
 {
     .test_desc          = "Test psa_cipher_generate_iv DES 64 bit key\n",
@@ -147,6 +194,21 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CBC_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc          = "Test psa_cipher_generate_iv AES - small iv buffer\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_16B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = expected_output,
+    .iv_size            = 8,
+    .expected_iv_length = 16,
+    .expected_status    = PSA_ERROR_BUFFER_TOO_SMALL
+},
+#endif
+
 #ifdef ARCH_TEST_DES_1KEY
 {
     .test_desc          = "Test psa_cipher_generate_iv DES - small iv buffer\n",

--- a/api-tests/dev_apis/crypto/test_c035/test_c035.c
+++ b/api-tests/dev_apis/crypto/test_c035/test_c035.c
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/api-tests/dev_apis/crypto/test_c035/test_c035.c
+++ b/api-tests/dev_apis/crypto/test_c035/test_c035.c
@@ -31,7 +31,9 @@ int32_t psa_cipher_set_iv_test(caller_security_t caller __UNUSED)
 #if ((defined(ARCH_TEST_CIPHER_MODE_CTR) && (defined(ARCH_TEST_AES_128) || \
       defined(ARCH_TEST_AES_192) || defined(ARCH_TEST_AES_256))) || \
       (defined(ARCH_TEST_CBC_AES_NO_PADDING) && (defined(ARCH_TEST_DES_1KEY) || \
-       defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY))))
+       defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY) || \
+      defined(ARCH_TEST_AES_128) || defined(ARCH_TEST_AES_192) || \
+      defined(ARCH_TEST_AES_256))))
     int32_t                 num_checks = sizeof(check1)/sizeof(check1[0]);
     int32_t                 i, status;
     psa_cipher_operation_t  operation;

--- a/api-tests/dev_apis/crypto/test_c035/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c035/test_data.h
@@ -32,7 +32,9 @@ typedef struct {
 #if ((defined(ARCH_TEST_CIPHER_MODE_CTR) && (defined(ARCH_TEST_AES_128) || \
       defined(ARCH_TEST_AES_192) || defined(ARCH_TEST_AES_256))) ||\
       (defined(ARCH_TEST_CBC_AES_NO_PADDING) && (defined(ARCH_TEST_DES_1KEY) || \
-       defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY))))
+       defined(ARCH_TEST_DES_2KEY) || defined(ARCH_TEST_DES_3KEY) || \
+      defined(ARCH_TEST_AES_128) || defined(ARCH_TEST_AES_192) || \
+      defined(ARCH_TEST_AES_256))))
 static const test_data check1[] = {
 #ifdef ARCH_TEST_CIPHER_MODE_CTR
 #ifdef ARCH_TEST_AES_128
@@ -79,6 +81,48 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CBC_AES_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc          = "Test psa_cipher_set_iv 16 Byte AES\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_16B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = iv,
+    .iv_length          = 16,
+    .expected_status    = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_192
+{
+    .test_desc          = "Test psa_cipher_set_iv 24 Byte AES\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_24B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = iv,
+    .iv_length          = 16,
+    .expected_status    = PSA_SUCCESS
+},
+#endif
+
+#ifdef ARCH_TEST_AES_256
+{
+    .test_desc          = "Test psa_cipher_set_iv 32 Byte AES\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_32B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = iv,
+    .iv_length          = 16,
+    .expected_status    = PSA_SUCCESS
+},
+#endif
+
 #ifdef ARCH_TEST_DES_1KEY
 {
     .test_desc          = "Test psa_cipher_set_iv DES 64 bit key\n",
@@ -139,6 +183,19 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CBC_AES_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc          = "Test psa_cipher_set_iv AES - small iv buffer\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_16B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = iv,
+    .iv_length          = 8,
+    .expected_status    = PSA_ERROR_INVALID_ARGUMENT
+},
+#endif
 #ifdef ARCH_TEST_DES_1KEY
 {
     .test_desc          = "Test psa_cipher_set_iv DES - small iv buffer\n",
@@ -171,6 +228,19 @@ static const test_data check1[] = {
 #endif
 
 #ifdef ARCH_TEST_CBC_AES_NO_PADDING
+#ifdef ARCH_TEST_AES_128
+{
+    .test_desc          = "Test psa_cipher_set_iv AES - large iv buffer\n",
+    .type               = PSA_KEY_TYPE_AES,
+    .data               = key_data,
+    .data_length        = AES_16B_KEY_SIZE,
+    .usage_flags        = PSA_KEY_USAGE_ENCRYPT,
+    .alg                = PSA_ALG_CBC_NO_PADDING,
+    .iv                 = iv,
+    .iv_length          = 17,
+    .expected_status    = PSA_ERROR_INVALID_ARGUMENT
+},
+#endif
 #ifdef ARCH_TEST_DES_1KEY
 {
     .test_desc          = "Test psa_cipher_set_iv DES - large iv buffer\n",

--- a/api-tests/dev_apis/crypto/test_c035/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c035/test_data.h
@@ -1,5 +1,5 @@
 /** @file
- * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2024, Arm Limited or its affiliates. All rights reserved.
  * SPDX-License-Identifier : Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -83,7 +83,7 @@ static const test_data check1[] = {
 #ifdef ARCH_TEST_CBC_AES_NO_PADDING
 #ifdef ARCH_TEST_AES_128
 {
-    .test_desc          = "Test psa_cipher_set_iv 16 Byte AES\n",
+    .test_desc          = "Test psa_cipher_set_iv 16 Byte AES in CBC mode\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_16B_KEY_SIZE,
@@ -97,7 +97,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_192
 {
-    .test_desc          = "Test psa_cipher_set_iv 24 Byte AES\n",
+    .test_desc          = "Test psa_cipher_set_iv 24 Byte AES in CBC mode\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_24B_KEY_SIZE,
@@ -111,7 +111,7 @@ static const test_data check1[] = {
 
 #ifdef ARCH_TEST_AES_256
 {
-    .test_desc          = "Test psa_cipher_set_iv 32 Byte AES\n",
+    .test_desc          = "Test psa_cipher_set_iv 32 Byte AES in CBC mode\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_32B_KEY_SIZE,
@@ -185,7 +185,7 @@ static const test_data check1[] = {
 #ifdef ARCH_TEST_CBC_AES_NO_PADDING
 #ifdef ARCH_TEST_AES_128
 {
-    .test_desc          = "Test psa_cipher_set_iv AES - small iv buffer\n",
+    .test_desc          = "Test psa_cipher_set_iv AES in CBC mode - small iv buffer\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_16B_KEY_SIZE,
@@ -230,7 +230,7 @@ static const test_data check1[] = {
 #ifdef ARCH_TEST_CBC_AES_NO_PADDING
 #ifdef ARCH_TEST_AES_128
 {
-    .test_desc          = "Test psa_cipher_set_iv AES - large iv buffer\n",
+    .test_desc          = "Test psa_cipher_set_iv AES in CBC mode - large iv buffer\n",
     .type               = PSA_KEY_TYPE_AES,
     .data               = key_data,
     .data_length        = AES_16B_KEY_SIZE,


### PR DESCRIPTION
Current test vectors have some lack of the AES in CBC mode. For us, it is impossible to pass the tests because for the time being our platform supports only AES in CBC and no CTR mode.

This PR introduces test vectors of AES in CBC mode and allows to define the failing algorithm for HKDF (currently it was `PSA_ALG_CTR`). All modifications are related to unsupported `PSA_ALG_CTR`.

