### PR TITLE
Test42 fix RSA public key import format

### DIFF
--- a/api-tests/dev_apis/crypto/test_c042/test_data.h
+++ b/api-tests/dev_apis/crypto/test_c042/test_data.h
@@ -236,8 +236,8 @@ static const test_data check1[] = {
 {
     .test_desc        = "Test psa_verify_hash - PSA_ALG_RSA_PSS_ANY_SALT\n",
     .type             = PSA_KEY_TYPE_RSA_PUBLIC_KEY,
-    .data             = rsa_key_pair_public_key,
-    .data_length      = 162,
+    .data             = rsa_128_key_data,
+    .data_length      = 140,
     .usage_flags      = PSA_KEY_USAGE_VERIFY_HASH,
     .alg              = PSA_ALG_RSA_PSS_ANY_SALT(PSA_ALG_SHA_256),
     .hash             = hash,


### PR DESCRIPTION
The `rsa_key_pair_public_key` array is used in test 42 as input to `psa_import_key` to get a public RSA key. The data contained in the array is formatted as a x509 "PublicKeyInfo" structure. However the only format which is mandatory to support in `psa_import_key` is "RSAPublicKey". `rsa_128_key_data` already has the expected format and is used in other tests as well (39, 40, 41, 42, 52, and 53)

C.f.  [Test39 fix RSA public key import format #320](https://github.com/ARM-software/psa-arch-tests/pull/320)  

Signed-off-by: Oberon microsystems AG