### PR TITLE
Fix tests 71, 72, 73, 74, 76, 77

### DIFF
--- a/api-tests/dev_apis/crypto/test_c071/test_c071.c
+++ b/api-tests/dev_apis/crypto/test_c071/test_c071.c
@@ -121,11 +121,14 @@ int32_t psa_pake_set_user_test(caller_security_t caller __UNUSED)
                                        &operation);
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(8));
 
-      /* Expect a bad state when psa_pake_set_user is called on aborted inactive operation object */
-        status = val->crypto_function(VAL_CRYPTO_PAKE_SET_USER,
-                                       &operation,
-                                       (const uint8_t*)"user", 4);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(9));
+        /* Expect a bad state when psa_pake_set_user is called on aborted inactive operation object */
+        if (check1[i].expected_status == PSA_SUCCESS) {
+            status = val->crypto_function(VAL_CRYPTO_PAKE_SET_USER,
+                                          &operation,
+                                          check1[i].user_id,
+                                          check1[i].user_id_len);
+            TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(9));
+        }
     }
 
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c071/test_c071.c
+++ b/api-tests/dev_apis/crypto/test_c071/test_c071.c
@@ -124,8 +124,7 @@ int32_t psa_pake_set_user_test(caller_security_t caller __UNUSED)
       /* Expect a bad state when psa_pake_set_user is called on aborted inactive operation object */
         status = val->crypto_function(VAL_CRYPTO_PAKE_SET_USER,
                                        &operation,
-                                       check1[i].user_id,
-                                       check1[i].user_id_len);
+                                       (const uint8_t*)"user", 4);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(9));
     }
 

--- a/api-tests/dev_apis/crypto/test_c072/test_c072.c
+++ b/api-tests/dev_apis/crypto/test_c072/test_c072.c
@@ -129,11 +129,14 @@ int32_t psa_pake_set_peer_test(caller_security_t caller __UNUSED)
                                        &operation);
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(9));
 
-      /* Expect a bad state when psa_pake_set_peer is called on aborted inactive operation object */
-        status = val->crypto_function(VAL_CRYPTO_PAKE_SET_PEER,
-                                       &operation,
-                                       (const uint8_t*)"peer", 4);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(10));
+        /* Expect a bad state when psa_pake_set_peer is called on aborted inactive operation object */
+        if (check1[i].expected_status == PSA_SUCCESS) {
+            status = val->crypto_function(VAL_CRYPTO_PAKE_SET_PEER,
+                                          &operation,
+                                          check1[i].peer_id,
+                                          check1[i].peer_id_len);
+            TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(10));
+        }
 }
     return VAL_STATUS_SUCCESS;
 }

--- a/api-tests/dev_apis/crypto/test_c072/test_c072.c
+++ b/api-tests/dev_apis/crypto/test_c072/test_c072.c
@@ -132,8 +132,7 @@ int32_t psa_pake_set_peer_test(caller_security_t caller __UNUSED)
       /* Expect a bad state when psa_pake_set_peer is called on aborted inactive operation object */
         status = val->crypto_function(VAL_CRYPTO_PAKE_SET_PEER,
                                        &operation,
-                                       check1[i].peer_id,
-                                       check1[i].peer_id_len);
+                                       (const uint8_t*)"peer", 4);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(10));
 }
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c073/test_c073.c
+++ b/api-tests/dev_apis/crypto/test_c073/test_c073.c
@@ -136,11 +136,14 @@ int32_t psa_pake_set_context_test(caller_security_t caller __UNUSED)
                                       &operation);
         TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(10));
 
-   /* Expect a bad state if psa_pake_set_context is called on aborted inactive operation object */
-        status = val->crypto_function(VAL_CRYPTO_PAKE_SET_CONTEXT,
-                                      &operation,
-                                      (const uint8_t*)"context", 7);
-        TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(11));
+        /* Expect a bad state if psa_pake_set_context is called on aborted inactive operation object */
+        if (check1[i].expected_status == PSA_SUCCESS) {
+            status = val->crypto_function(VAL_CRYPTO_PAKE_SET_CONTEXT,
+                                          &operation,
+                                          check1[i].context,
+                                          check1[i].context_len);
+            TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(11));
+        }
   }
     return VAL_STATUS_SUCCESS;
 }

--- a/api-tests/dev_apis/crypto/test_c073/test_c073.c
+++ b/api-tests/dev_apis/crypto/test_c073/test_c073.c
@@ -139,8 +139,7 @@ int32_t psa_pake_set_context_test(caller_security_t caller __UNUSED)
    /* Expect a bad state if psa_pake_set_context is called on aborted inactive operation object */
         status = val->crypto_function(VAL_CRYPTO_PAKE_SET_CONTEXT,
                                       &operation,
-                                      check1[i].context,
-                                      check1[i].context_len);
+                                      (const uint8_t*)"context", 7);
         TEST_ASSERT_EQUAL(status, PSA_ERROR_BAD_STATE, TEST_CHECKPOINT_NUM(11));
   }
     return VAL_STATUS_SUCCESS;

--- a/api-tests/dev_apis/crypto/test_c074/test_c074.c
+++ b/api-tests/dev_apis/crypto/test_c074/test_c074.c
@@ -391,7 +391,7 @@ int32_t psa_pake_output_test(caller_security_t caller __UNUSED)
 
       }
 
-      if (PSA_ALG_JPAKE(PSA_ALG_SHA_256))
+      if (PSA_ALG_IS_JPAKE (check1[i].alg))
          {
            /* Abort the PAKE operation object */
          status = val->crypto_function(VAL_CRYPTO_PAKE_ABORT, &user);

--- a/api-tests/dev_apis/crypto/test_c074/test_c074.c
+++ b/api-tests/dev_apis/crypto/test_c074/test_c074.c
@@ -391,7 +391,7 @@ int32_t psa_pake_output_test(caller_security_t caller __UNUSED)
 
       }
 
-      if (PSA_ALG_IS_JPAKE (check1[i].alg))
+      if (PSA_ALG_IS_JPAKE(check1[i].alg))
          {
            /* Abort the PAKE operation object */
          status = val->crypto_function(VAL_CRYPTO_PAKE_ABORT, &user);

--- a/api-tests/dev_apis/crypto/test_c076/test_c076.c
+++ b/api-tests/dev_apis/crypto/test_c076/test_c076.c
@@ -105,6 +105,10 @@ int32_t psa_pake_abort_test(caller_security_t caller __UNUSED)
                                       &operation);
         TEST_ASSERT_EQUAL(status, check1[i].expected_status, TEST_CHECKPOINT_NUM(6));
 
+        /* Destroy the key */
+        status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, key);
+        TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(7));
+
      }
     return VAL_STATUS_SUCCESS;
 }

--- a/api-tests/dev_apis/crypto/test_c077/test_c077.c
+++ b/api-tests/dev_apis/crypto/test_c077/test_c077.c
@@ -299,7 +299,7 @@ int32_t psa_pake_get_shared_key_test(caller_security_t caller __UNUSED)
     psa_pake_operation_t    client = PSA_PAKE_OPERATION_INIT;
     psa_pake_operation_t    server = PSA_PAKE_OPERATION_INIT;
     psa_key_id_t            pw_key, ckey, skey;
-    psa_key_id_t            shared_key;
+    psa_key_id_t            shared_key, shared_key1;
 
     if (num_checks == 0)
     {
@@ -479,14 +479,14 @@ int32_t psa_pake_get_shared_key_test(caller_security_t caller __UNUSED)
              }
 
              status = val->crypto_function(VAL_CRYPTO_PAKE_GET_SHARED_KEY,
-                                           &server, &attributes, &shared_key);
+                                           &server, &attributes, &shared_key1);
              TEST_ASSERT_DUAL(status, check1[i].expected_status[0],
                                       check1[i].expected_status[1], TEST_CHECKPOINT_NUM(13));
 
              if (status == PSA_SUCCESS) {
-             status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, shared_key);
-             TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(14));
-
+               /* Destroy the key */
+               status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, shared_key1);
+               TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(14));
             }
            }
 
@@ -507,7 +507,6 @@ int32_t psa_pake_get_shared_key_test(caller_security_t caller __UNUSED)
 
               status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, skey);
               TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(19));
-
             }
 
    }

--- a/api-tests/dev_apis/crypto/test_c077/test_c077.c
+++ b/api-tests/dev_apis/crypto/test_c077/test_c077.c
@@ -472,6 +472,12 @@ int32_t psa_pake_get_shared_key_test(caller_security_t caller __UNUSED)
              TEST_ASSERT_DUAL(status, check1[i].expected_status[0],
                                       check1[i].expected_status[1], TEST_CHECKPOINT_NUM(12));
 
+             if (status == PSA_SUCCESS) {
+               /* Destroy the key */
+               status = val->crypto_function(VAL_CRYPTO_DESTROY_KEY, shared_key);
+               TEST_ASSERT_EQUAL(status, PSA_SUCCESS, TEST_CHECKPOINT_NUM(14));
+             }
+
              status = val->crypto_function(VAL_CRYPTO_PAKE_GET_SHARED_KEY,
                                            &server, &attributes, &shared_key);
              TEST_ASSERT_DUAL(status, check1[i].expected_status[0],


### PR DESCRIPTION
Fix tests 71, 72, 73 to avoid invalid argument.
Fix test 74 wrong macro.
Fix tests 76, 77 missing destroy key.

Signed-off-by: Oberon microsystems AG