### PR TITLE
platform: Add support for NXP board frdmmcxn947 in psa-arch-test

### DIFF
--- a/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_attestation_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_attestation_config.h
@@ -1,0 +1,110 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_ATTESTATION_CONFIG_H_
+#define _PAL_ATTESTATION_CONFIG_H_
+
+#define COSE_ALGORITHM_ES256             -7
+#define COSE_ALG_SHA256_PROPRIETARY      -72000
+
+#define USEFUL_BUF_MAKE_STACK_UB UsefulBuf_MAKE_STACK_UB
+
+#define COSE_SIG_CONTEXT_STRING_SIGNATURE1 "Signature1"
+
+/* Private value. Intentionally not documented for Doxygen.
+ * This is the size allocated for the encoded protected headers.  It
+ * needs to be big enough for make_protected_header() to succeed. It
+ * currently sized for one header with an algorithm ID up to 32 bits
+ * long -- one byte for the wrapping map, one byte for the label, 5
+ * bytes for the ID. If this is made accidentially too small, QCBOR will
+ * only return an error, and not overrun any buffers.
+ *
+ * 9 extra bytes are added, rounding it up to 16 total, in case some
+ * other protected header is to be added.
+ */
+#define T_COSE_SIGN1_MAX_PROT_HEADER (1+1+5+9)
+
+/**
+ * This is the size of the first part of the CBOR encoded TBS
+ * bytes. It is around 20 bytes. See create_tbs_hash().
+ */
+#define T_COSE_SIZE_OF_TBS \
+    1 + /* For opening the array */ \
+    sizeof(COSE_SIG_CONTEXT_STRING_SIGNATURE1) + /* "Signature1" */ \
+    2 + /* Overhead for encoding string */ \
+    T_COSE_SIGN1_MAX_PROT_HEADER + /* entire protected headers */ \
+    3 * (/* 3 NULL bstrs for fields not used */ \
+        1 /* size of a NULL bstr */  \
+    )
+#define NULL_USEFUL_BUF_C  NULLUsefulBufC
+
+#define ATTEST_PUBLIC_KEY_SLOT                  4
+#define ECC_CURVE_SECP256R1_PULBIC_KEY_LENGTH   (1 + 2 * PSA_BITS_TO_BYTES(256))
+
+typedef struct {
+    uint8_t  *pubx_key;
+    size_t    pubx_key_size;
+    uint8_t  *puby_key;
+    size_t    puby_key_size;
+} ecc_key_t;
+
+struct ecc_public_key_t {
+    const uint8_t a;
+    uint8_t public_key[]; /* X-coordinate || Y-coordinate */
+};
+
+static const struct ecc_public_key_t attest_public_key = {
+     /* Constant byte */
+     0x04,
+     /* X-coordinate */
+     {0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
+      0x75, 0x15, 0x76, 0xAD, 0x45, 0x99, 0xB0, 0x7A,
+      0xDF, 0x93, 0x8D, 0xA3, 0xBB, 0x0B, 0xD1, 0x7D,
+      0x00, 0x36, 0xED, 0x49, 0xA2, 0xD0, 0xFC, 0x3F,
+     /* Y-coordinate */
+      0xBF, 0xCD, 0xFA, 0x89, 0x56, 0xB5, 0x68, 0xBF,
+      0xDB, 0x86, 0x73, 0xE6, 0x48, 0xD8, 0xB5, 0x8D,
+      0x92, 0x99, 0x55, 0xB1, 0x4A, 0x26, 0xC3, 0x08,
+      0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64},
+};
+
+static const uint8_t initial_attestation_public_x_key[] = {
+    0x79, 0xEB, 0xA9, 0x0E, 0x8B, 0xF4, 0x50, 0xA6,
+    0x75, 0x15, 0x76, 0xAD, 0x45, 0x99, 0xB0, 0x7A,
+    0xDF, 0x93, 0x8D, 0xA3, 0xBB, 0x0B, 0xD1, 0x7D,
+    0x00, 0x36, 0xED, 0x49, 0xA2, 0xD0, 0xFC, 0x3F
+};
+
+static const uint8_t initial_attestation_public_y_key[] = {
+    0xBF, 0xCD, 0xFA, 0x89, 0x56, 0xB5, 0x68, 0xBF,
+    0xDB, 0x86, 0x73, 0xE6, 0x48, 0xD8, 0xB5, 0x8D,
+    0x92, 0x99, 0x55, 0xB1, 0x4A, 0x26, 0xC3, 0x08,
+    0x0F, 0x34, 0x11, 0x7D, 0x97, 0x1D, 0x68, 0x64
+};
+
+/* Initialize the structure with given public key */
+static const ecc_key_t attest_key = {
+        (uint8_t *)initial_attestation_public_x_key,
+        sizeof(initial_attestation_public_x_key),
+        (uint8_t *)initial_attestation_public_y_key,
+        sizeof(initial_attestation_public_y_key)
+};
+
+#endif /* _PAL_ATTESTATION_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_config.h
@@ -1,0 +1,162 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_CONFIG_H_
+#define _PAL_CONFIG_H_
+
+#include "pal_crypto_config.h"
+#include "pal_attestation_config.h"
+#include "pal_storage_config.h"
+
+/*==========================  PLATFORM CONFIGURATIONS START  ==========================*/
+
+// UART device info
+#define UART_NUM                               1
+
+#define UART_0_BASE                            0x400B4000  // UART0_NS
+#define UART_0_SIZE                            0xFFF
+#define UART_0_INTR_ID                         0xFF
+#define UART_0_PERMISSION                      TYPE_READ_WRITE
+
+// Watchdog device info
+// In this implementation we don't assume there's a watchdog. Watchdog PAL
+// functions all just return SUCCESS, so the values below don't mean much.
+#define WATCHDOG_NUM                           0
+
+#define WATCHDOG_0_BASE                        0x0
+#define WATCHDOG_0_SIZE                        0x0
+#define WATCHDOG_0_INTR_ID                     0x0
+#define WATCHDOG_0_PERMISSION                  TYPE_READ_WRITE
+#define WATCHDOG_0_NUM_OF_TICK_PER_MICRO_SEC   0x0
+#define WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_LOW    0x0
+#define WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_MEDIUM 0x0
+#define WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_HIGH   0x0
+#define WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_CRYPTO 0x0
+
+// Range of 1KB Non-volatile memory to preserve data over reset. Ex, NVRAM and FLASH
+// Range of 1KB Non-volatile memory to preserve data over reset.
+// This is an emulation in RAM. It uses the last 1Kib of RAM available to NS.
+// Note, that RAM usage for NS is restricted, the value here must match up with
+// The value that TF-M allows for NS (see also 
+// trusted-firmware-m\platform\ext\target\nxp\<board>\partition\region_defs.h).
+// The size available to NS also needs to be known to the linker when building 
+// NS projects. When building this application, it is recommended to not allow 
+// usage of the memory used for nvmem emulation. How to achieve this depends on 
+// the build system.
+// For zephyr builds usually a _ns board configuration holds the available memory 
+// for the NS partition. 
+// Such settings split over multiple repositories tend to de-sync, so please take 
+// care and the following numbers with extra-caution!
+
+#define NVMEM_NUM                              1
+#define NVMEM_0_START                          0x2005FC00
+#define NVMEM_0_END                            0x20060000
+#define NVMEM_0_PERMISSION                     TYPE_READ_WRITE
+
+/*==========================  PLATFORM CONFIGURATIONS END  ============================*/
+
+
+/* Define PSA test suite dependent macros for non-cmake build */
+#if !defined(PSA_CMAKE_BUILD)
+
+/* Print verbosity = TEST */
+#define VERBOSITY 3
+
+/* NSPE or SPE VAL build? */
+#define VAL_NSPE_BUILD
+
+/* NSPE or SPE TEST build? */
+#define NONSECURE_TEST_BUILD
+
+/* If not defined, skip watchdog programming */
+// #define WATCHDOG_AVAILABLE
+
+/* Are Dynamic memory APIs available to secure partition? */
+// #define SP_HEAP_MEM_SUPP
+
+/* PSA Isolation level supported by platform */
+#define PLATFORM_PSA_ISOLATION_LEVEL 2
+#endif /* PSA_CMAKE_BUILD */
+
+/* Version of crypto spec used in attestation */
+#define CRYPTO_VERSION_BETA3
+
+#ifndef PLATFORM_HAS_ATTEST_PK
+/* Use hardcoded public key */
+#define PLATFORM_OVERRIDE_ATTEST_PK
+#endif
+
+/* UART base address assigned */
+#define PLATFORM_UART_BASE UART_0_BASE
+
+/* Watchdog device configurations assigned */
+#define PLATFORM_WD_BASE                        WATCHDOG_0_BASE
+#define PLATFORM_WD_NUM_OF_TICK_PER_MICRO_SEC   WATCHDOG_0_NUM_OF_TICK_PER_MICRO_SEC
+#define PLATFORM_WD_TIMEOUT_IN_MICRO_SEC_LOW    WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_LOW
+#define PLATFORM_WD_TIMEOUT_IN_MICRO_SEC_MEDIUM WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_LOW
+#define PLATFORM_WD_TIMEOUT_IN_MICRO_SEC_HIGH   WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_LOW
+#define PLATFORM_WD_TIMEOUT_IN_MICRO_SEC_CRYPTO WATCHDOG_0_TIMEOUT_IN_MICRO_SEC_CRYPTO
+
+/* Non-volatile memory base address assigned */
+#define PLATFORM_NVM_BASE NVMEM_0_START
+
+/*
+ * Include of PSA defined Header files
+ */
+#ifdef IPC
+/* psa/client.h: Contains the PSA Client API elements */
+#include "psa/client.h"
+
+/*
+ * psa_manifest/sid.h:  Macro definitions derived from manifest files that map from RoT Service
+ * names to Service IDs (SIDs). Partition manifest parse build tool must provide the implementation
+ * of this file.
+*/
+#include "psa_manifest/sid.h"
+
+/*
+ * psa_manifest/pid.h: Secure Partition IDs
+ * Macro definitions that map from Secure Partition names to Secure Partition IDs.
+ * Partition manifest parse build tool must provide the implementation of this file.
+*/
+#include "psa_manifest/pid.h"
+#endif
+
+#ifdef CRYPTO
+/* psa/crypto.h: Contains the PSA Crypto API elements */
+#include "psa/crypto.h"
+#endif
+
+#if defined(INTERNAL_TRUSTED_STORAGE) || defined(STORAGE)
+/* psa/internal_trusted_storage.h: Contains the PSA ITS API elements */
+#include "psa/internal_trusted_storage.h"
+#endif
+
+#if defined(PROTECTED_STORAGE) || defined(STORAGE)
+/* psa/protected_storage.h: Contains the PSA PS API elements */
+#include "psa/protected_storage.h"
+#endif
+
+#ifdef INITIAL_ATTESTATION
+/* psa/initial_attestation.h: Contains the PSA Initial Attestation API elements */
+#include "psa/initial_attestation.h"
+#endif
+
+#endif /* _PAL_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_crypto_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_crypto_config.h
@@ -1,0 +1,444 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+/*
+ * \file pal_crypto_config.h
+ *
+ * \brief Configuration options for crypto tests (set of defines)
+ *
+ *  This set of compile-time options may be used to enable
+ *  or disable features selectively for crypto test suite
+ */
+
+#ifndef _PAL_CRYPTO_CONFIG_H_
+#define _PAL_CRYPTO_CONFIG_H_
+/**
+ * \def ARCH_TEST_RSA
+ *
+ * Enable the RSA public-key cryptosystem.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_RSA
+#define ARCH_TEST_RSA_1024
+#define ARCH_TEST_RSA_2048
+#define ARCH_TEST_RSA_3072
+#endif
+#endif
+
+/**
+ * \def  ARCH_TEST_ECC
+ * \def  ARCH_TEST_ECC_CURVE_SECPXXXR1
+ *
+ * Enable the elliptic curve
+ * Enable specific curves within the Elliptic Curve
+ * module.  By default all supported curves are enabled.
+ *
+ * Requires: ARCH_TEST_ECC
+ * Comment macros to disable the curve
+ */
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_ECC
+#define ARCH_TEST_ECC_CURVE_SECP192R1
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_ECC_CURVE_SECP224R1
+#endif
+#define ARCH_TEST_ECC_CURVE_SECP256R1
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_ECC_CURVE_SECP384R1
+#endif
+#endif
+/* curves of size <255 are obsolete algorithms, should be disabled. */
+#undef ARCH_TEST_ECC_CURVE_SECP192R1
+#undef ARCH_TEST_ECC_CURVE_SECP224R1
+
+/**
+ * \def ARCH_TEST_AES
+ *
+ * Enable the AES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_AES
+#define ARCH_TEST_AES_128
+#define ARCH_TEST_AES_192
+#define ARCH_TEST_AES_256
+#define ARCH_TEST_AES_512
+
+/**
+ * \def  ARCH_TEST_DES
+ *
+ * Enable the DES block cipher.
+ * By default all supported keys are enabled.
+ *
+ * Comment macros to disable the types
+ */
+/* Following test(checks) have been disabled, as these are weak algos 
+ * and will not be supported by NXP platforms by default. */
+//#define ARCH_TEST_DES
+//#define ARCH_TEST_DES_1KEY
+//#define ARCH_TEST_DES_2KEY
+//#define ARCH_TEST_DES_3KEY
+
+/**
+ * \def  ARCH_TEST_RAW
+ *
+ * A "key" of this type cannot be used for any cryptographic operation.
+ * Applications may use this type to store arbitrary data in the keystore.
+ */
+#define ARCH_TEST_RAW
+
+/**
+ * \def ARCH_TEST_CIPHER
+ *
+ * Enable the generic cipher layer.
+ */
+
+#define ARCH_TEST_CIPHER
+
+/**
+ * \def ARCH_TEST_ARC4
+ *
+ * Enable the ARC4 key type.
+ */
+/* Following test(checks) have been disabled, as its a weak algo and will not be 
+ * supported by NXP platforms by default. */
+//#define ARCH_TEST_ARC4
+
+/**
+ * \def ARCH_TEST_CIPHER_MODE_CTR
+ *
+ * Enable Counter Block Cipher mode (CTR) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPHER
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CIPHER_MODE_CTR
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CIPHER_MODE_CFB
+ *
+ * Enable Cipher Feedback mode (CFB) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPHER
+ */
+#define ARCH_TEST_CIPHER_MODE_CFB
+
+/**
+ * \def ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Enable Cipher Block Chaining mode (CBC) for symmetric ciphers.
+ *
+ * Requires: ARCH_TEST_CIPHER
+ */
+#define ARCH_TEST_CIPHER_MODE_CBC
+
+/**
+ * \def ARCH_TEST_CTR_AES
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_AES, ARCH_TEST_CIPHER_MODE_CTR
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CTR_AES
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CBC_AES
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_AES, ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#define ARCH_TEST_CBC_AES
+#define ARCH_TEST_CBC_AES_NO_PADDING
+
+/**
+ * \def ARCH_TEST_CBC_NO_PADDING
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CBC_NO_PADDING
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CFB_AES
+ *
+ * Requires: ARCH_TEST_CIPHER, ARCH_TEST_AES, ARCH_TEST_CIPHER_MODE_CFB
+ */
+#define ARCH_TEST_CFB_AES
+
+/**
+ * \def ARCH_TEST_PKCS1V15_*
+ *
+ * Enable support for PKCS#1 v1.5 encoding.
+ * Enable support for PKCS#1 v1.5 operations.
+ * Enable support for RSA-OAEP
+ *
+ * Requires: ARCH_TEST_RSA, ARCH_TEST_PKCS1V15
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_PKCS1V15
+#define ARCH_TEST_RSA_PKCS1V15_SIGN
+#define ARCH_TEST_RSA_PKCS1V15_SIGN_RAW
+#define ARCH_TEST_RSA_PKCS1V15_CRYPT
+#define ARCH_TEST_RSA_OAEP
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_CBC_PKCS7
+ *
+ * Requires: ARCH_TEST_CIPHER_MODE_CBC
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CBC_PKCS7
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_ASYMMETRIC_ENCRYPTION
+ *
+ * Enable support for Asymmetric encryption algorithms
+ */
+#define ARCH_TEST_ASYMMETRIC_ENCRYPTION
+
+/**
+ * \def ARCH_TEST_HASH
+ *
+ * Enable the hash algorithm.
+ */
+#define ARCH_TEST_HASH
+
+/**
+ * \def  ARCH_TEST_HMAC
+ *
+ * The key policy determines which underlying hash algorithm the key can be
+ * used for.
+ *
+ * Requires: ARCH_TEST_HASH
+ */
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_MDX
+ * \def ARCH_TEST_SHAXXX
+ *
+ * Enable the MDX algorithm.
+ * Enable the SHAXXX algorithm.
+ *
+ * Requires: ARCH_TEST_HASH
+ *
+ * Comment macros to disable the types
+ */
+/* Following test(checks) have been disabled, as these are weak algo and will not 
+ * be supported by NXP platforms by default. */
+//#define ARCH_TEST_MD2
+//#define ARCH_TEST_MD4
+//#define ARCH_TEST_MD5
+//#define ARCH_TEST_RIPEMD160
+//#define ARCH_TEST_SHA1
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_SHA224
+#endif
+#define ARCH_TEST_SHA256
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_SHA384
+#define ARCH_TEST_SHA512
+#endif
+#endif
+//#define ARCH_TEST_SHA512_224
+//#define ARCH_TEST_SHA512_256
+//#define ARCH_TEST_SHA3_224
+//#define ARCH_TEST_SHA3_256
+//#define ARCH_TEST_SHA3_384
+//#define ARCH_TEST_SHA3_512
+
+// SHA224 is not in NXP scope of testing
+#undef ARCH_TEST_SHA224
+
+/**
+ * \def ARCH_TEST_HKDF
+ *
+ * Enable the HKDF algorithm (RFC 5869).
+ *
+ * Requires: ARCH_TEST_HASH
+*/
+#define ARCH_TEST_HKDF
+
+/**
+ * \def ARCH_TEST_TLS12_PRF
+ *
+ * Enable the TLS-1.2 PRF algorithm (RFC 5246).
+ *
+ * Requires: ARCH_TEST_HASH
+*/
+#define ARCH_TEST_TLS12_PRF
+
+/**
+ * \def ARCH_TEST_xMAC
+ *
+ * Enable the xMAC (Cipher/Hash/G-based Message Authentication Code) mode for block
+ * ciphers.
+ * Requires: ARCH_TEST_AES or ARCH_TEST_DES
+ *
+ * Comment macros to disable the types
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_CMAC
+#endif
+#endif
+//#define ARCH_TEST_GMAC
+#define ARCH_TEST_HMAC
+
+/**
+ * \def ARCH_TEST_CCM
+ *
+ * Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher.
+ *
+ * Requires: ARCH_TEST_AES
+ */
+#define ARCH_TEST_CCM
+
+/**
+ * \def ARCH_TEST_GCM
+ *
+ * Enable the Galois/Counter Mode (GCM) for AES.
+ *
+ * Requires: ARCH_TEST_AES
+ *
+ */
+#ifndef TF_M_PROFILE_SMALL
+#ifndef TF_M_PROFILE_MEDIUM
+#define ARCH_TEST_GCM
+#endif
+#endif
+
+/**
+ * \def ARCH_TEST_TRUNCATED_MAC
+ *
+ * Enable support for RFC 6066 truncated HMAC in SSL.
+ *
+ * Comment this macro to disable support for truncated HMAC in SSL
+ */
+#define ARCH_TEST_TRUNCATED_MAC
+
+
+/**
+ * \def ARCH_TEST_ECDH
+ *
+ * Enable the elliptic curve Diffie-Hellman library.
+ *
+ * Requires: ARCH_TEST_ECC
+ */
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_ECDH
+#endif
+
+/**
+ * \def ARCH_TEST_ECDSA
+ *
+ * Enable the elliptic curve DSA library.
+ * Requires: ARCH_TEST_ECC
+ */
+#ifndef TF_M_PROFILE_SMALL
+#define ARCH_TEST_ECDSA
+#endif
+
+/**
+ * \def ARCH_TEST_DETERMINISTIC_ECDSA
+ *
+ * Enable deterministic ECDSA (RFC 6979).
+*/
+#define ARCH_TEST_DETERMINISTIC_ECDSA
+
+/**
+ * \def ARCH_TEST_ECC_ASYMMETRIC_API_SUPPORT
+ *
+ * Enable ECC support for asymmetric API.
+*/
+//#define ARCH_TEST_ECC_ASYMMETRIC_API_SUPPORT
+
+/**
+ * \def ARCH_TEST_HASH_SUSPEND
+ *
+ * Enable has suspend.
+*/
+//#define ARCH_TEST_HASH_SUSPEND
+
+/**
+ * \def ARCH_TEST_HASH_RESUME
+ *
+ * Enable has resume.
+*/
+//#define ARCH_TEST_HASH_RESUME
+
+/**
+ * \def ARCH_TEST_PBKDF2
+ *
+ * Enable the Password-based Key derivation functions - 2.
+*/
+#define ARCH_TEST_PBKDF2
+
+/**
+ * \def ARCH_TEST_AEAD_MULTISTAGE_OFF
+ *
+ * Enable unsupported multi-stage AEAD test-cases.
+*/
+//#define ARCH_TEST_AEAD_MULTISTAGE_OFF
+
+/**
+ * \def ARCH_TEST_CCM_MIN_TAG_LEN_8
+ *
+ * Enable possibility to set the minimal Tag length of 8 bytes.
+*/
+//#define ARCH_TEST_CCM_MIN_TAG_LEN_8
+
+/**
+ * \def ARCH_TEST_HASH_CLONE_UNSUPPORTED
+ *
+ * Enable unsupported hash clones in tests.
+*/
+//#define ARCH_TEST_HASH_CLONE_UNSUPPORTED
+
+#include "pal_crypto_config_check.h"
+
+#endif /* _PAL_CRYPTO_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_driver_intf.c
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_driver_intf.c
@@ -1,0 +1,147 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#include "pal_common.h"
+#include "pal_uart.h"
+#include "pal_nvmem.h"
+#include <stdio.h>
+
+/* Regression test status reporting buffer */
+uint8_t test_status_buffer[256]  = {0};
+int32_t tfm_platform_system_reset(void);
+
+/**
+    @brief    - This function initializes the UART
+    @param    - uart base addr
+    @return   - SUCCESS/FAILURE
+**/
+int pal_uart_init_ns(void)
+{
+    pal_uart_pl011_init((uint32_t) PLATFORM_UART_BASE);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - This function parses the input string and writes bytes into UART TX FIFO
+    @param    - str      : Input String
+              - data     : Value for format specifier
+    @return   - SUCCESS/FAILURE
+**/
+int pal_print(uint8_t c)
+{
+    printf("%c", (char)c);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Initializes an hardware watchdog timer
+    @param           - base_addr       : Base address of the watchdog module
+                     - time_us         : Time in micro seconds
+                     - timer_tick_us   : Number of ticks per micro second
+    @return          - SUCCESS/FAILURE
+**/
+int pal_wd_timer_init_ns(uint32_t time_us, uint32_t timer_tick_us)
+{
+    (void) (time_us);
+    (void) (timer_tick_us);
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Enables a hardware watchdog timer
+    @param           - Void
+    @return          - SUCCESS/FAILURE
+**/
+int pal_watchdog_enable(void)
+{
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief           - Disables a hardware watchdog timer
+    @param           - Void
+    @return          - SUCCESS/FAILURE
+**/
+int pal_watchdog_disable(void)
+{
+    return PAL_STATUS_SUCCESS;
+}
+
+/**
+    @brief    - Reads from given non-volatile address.
+    @param    - offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvm_read(uint32_t offset, void *buffer, size_t size)
+{
+    if (nvmem_read((addr_t) PLATFORM_NVM_BASE, offset, buffer, size))
+    {
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+}
+
+/**
+    @brief    - Writes into given non-volatile address.
+    @param    - offset  : Offset
+                buffer  : Pointer to source address
+                size    : Number of bytes
+    @return   - SUCCESS/FAILURE
+**/
+int pal_nvm_write(uint32_t offset, void *buffer, size_t size)
+{
+    if (nvmem_write((addr_t) PLATFORM_NVM_BASE, offset, buffer, size))
+    {
+        return PAL_STATUS_SUCCESS;
+    }
+    else
+    {
+        return PAL_STATUS_ERROR;
+    }
+}
+
+/**
+ *   @brief    - Terminates the simulation at the end of all tests completion.
+ *               By default, it put cpus into power down mode.
+ *   @param    - void
+ *   @return   - void
+**/
+void pal_terminate_simulation(void)
+{
+    /* Add logic to terminate the simluation */
+
+    while (1)
+        __asm volatile("WFI");
+}
+
+/**
+ *   @brief    - Resets the system.
+ *   @param    - void
+ *   @return   - SUCCESS/FAILURE
+**/
+int pal_system_reset(void)
+{
+    return tfm_platform_system_reset();
+}

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_storage_config.h
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/nspe/pal_storage_config.h
@@ -1,0 +1,27 @@
+/** @file
+ * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Copyright 2026 NXP
+ * SPDX-License-Identifier : Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+#ifndef _PAL_STORAGE_CONFIG_H_
+#define _PAL_STORAGE_CONFIG_H_
+
+/* Platform specific max UID's size */
+#define ARCH_TEST_STORAGE_UID_MAX_SIZE 512
+
+#endif /* _PAL_STORAGE_CONFIG_H_ */

--- a/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/target.cmake
+++ b/api-tests/platform/targets/tgt_dev_apis_tfm_frdmmcxn947/target.cmake
@@ -1,0 +1,141 @@
+#/** @file
+# * Copyright (c) 2026, Arm Limited or its affiliates. All rights reserved.
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Copyright 2026 NXP
+# * SPDX-License-Identifier : Apache-2.0
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *  http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+#**/
+
+# No watchdog is configured for this platform.
+set(WATCHDOG_AVAILABLE 0)
+
+# PAL C source files part of NSPE library
+list(APPEND PAL_SRC_C_NSPE )
+
+# PAL ASM source files part of NSPE library
+list(APPEND PAL_SRC_ASM_NSPE )
+
+# PAL C source files part of SPE library - driver partition
+list(APPEND PAL_SRC_C_DRIVER_SP )
+
+# PAL ASM source files part of SPE library - driver partition
+list(APPEND PAL_SRC_ASM_DRIVER_SP )
+
+# Now this is a major hack, but there is no way to get a 
+# platform specific header file (this platform overrides 
+# tfm_builtin_key_ids.h) included here. Even if the header 
+# file is part of TF-M's install interface, this is still 
+# not an option as the test suite typically is part of the 
+# TF-M build itself which means the install has not yet 
+# happened and the interface files are only at their source 
+# location but not at the install location.
+# So we need that platform specific include path here which 
+# depends on the file structure in TF-M (which probalby is 
+# reasonably stable at this point)...
+list(APPEND PSA_INCLUDE_PATHS ${CMAKE_SOURCE_DIR}/platform/ext/target/nxp/frdmmcxn947/Device/Include/)
+
+# Listing all the sources required for given target
+if(${SUITE} STREQUAL "IPC")
+	list(APPEND PAL_SRC_C_NSPE
+		# driver functionalities are implemented as RoT-services
+		# and secure and non-secure clients will call to these RoT-services to get appropriate driver services.
+		${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/common/pal_client_api_intf.c
+		${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/common/pal_driver_ipc_intf.c
+	)
+	list(APPEND PAL_SRC_C_DRIVER_SP
+		# Driver files will be compiled as part of driver partition
+		${PSA_ROOT_DIR}/platform/targets/${TARGET}/spe/pal_driver_intf.c
+		${PSA_ROOT_DIR}/platform/drivers/nvmem/pal_nvmem.c
+		${PSA_ROOT_DIR}/platform/drivers/uart/pl011/pal_uart.c
+		${PSA_ROOT_DIR}/platform/drivers/watchdog/cmsdk/pal_wd_cmsdk.c
+	)
+else()
+	list(APPEND PAL_SRC_C_NSPE
+		# driver files will be compiled as part of NSPE
+		${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe/pal_driver_intf.c
+		${PSA_ROOT_DIR}/platform/drivers/nvmem/pal_nvmem.c
+		${PSA_ROOT_DIR}/platform/drivers/uart/pl011/pal_uart.c
+		${PSA_ROOT_DIR}/platform/drivers/watchdog/cmsdk/pal_wd_cmsdk.c
+	)
+endif()
+
+if(${SUITE} STREQUAL "CRYPTO")
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto/pal_crypto_intf.c
+	)
+endif()
+if((${SUITE} STREQUAL "PROTECTED_STORAGE") OR (${SUITE} STREQUAL "STORAGE"))
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/protected_storage/pal_protected_storage_intf.c
+	)
+endif()
+if((${SUITE} STREQUAL "INTERNAL_TRUSTED_STORAGE") OR (${SUITE} STREQUAL "STORAGE"))
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage/pal_internal_trusted_storage_intf.c
+	)
+endif()
+if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
+	list(APPEND PAL_SRC_C_NSPE
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation/pal_attestation_intf.c
+		${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation/pal_attestation_crypto.c
+                ${PSA_TARGET_QCBOR}/src/UsefulBuf.c
+                ${PSA_TARGET_QCBOR}/src/ieee754.c
+                ${PSA_TARGET_QCBOR}/src/qcbor_decode.c
+                ${PSA_TARGET_QCBOR}/src/qcbor_encode.c
+	)
+endif()
+
+# Create NSPE library
+add_library(${PSA_TARGET_PAL_NSPE_LIB} STATIC ${PAL_SRC_C_NSPE} ${PAL_SRC_ASM_NSPE})
+
+# PSA Include directories
+foreach(psa_inc_path ${PSA_INCLUDE_PATHS})
+	target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE ${psa_inc_path})
+endforeach()
+
+list(APPEND PAL_DRIVER_INCLUDE_PATHS
+	${PSA_ROOT_DIR}/platform/drivers/nvmem
+	${PSA_ROOT_DIR}/platform/drivers/uart/pl011
+	${PSA_ROOT_DIR}/platform/drivers/watchdog/cmsdk
+)
+
+if(${SUITE} STREQUAL "IPC")
+    # driver files will be compiled as part of NSPE
+    target_include_directories(${PSA_TARGET_DRIVER_PARTITION_LIB} PRIVATE
+        ${PAL_DRIVER_INCLUDE_PATHS}
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/protected_storage
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation
+    )
+else()
+    # driver files will be compiled as part of NSPE
+    target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
+        ${PAL_DRIVER_INCLUDE_PATHS}
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/crypto
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/protected_storage
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/internal_trusted_storage
+        ${PSA_ROOT_DIR}/platform/targets/common/nspe/initial_attestation
+        ${PSA_ROOT_DIR}/platform/targets/${TARGET}/nspe
+    )
+endif()
+
+if(${SUITE} STREQUAL "INITIAL_ATTESTATION")
+target_include_directories(${PSA_TARGET_PAL_NSPE_LIB} PRIVATE
+	${PSA_QCBOR_INCLUDE_PATH}
+)
+endif()


### PR DESCRIPTION
Add PSA API test support for MCXN947 platform
Introduced "tgt_dev_apis_tfm_frdmmcxn947" to enable full PSA API test execution on MCXN947, improving compliance and test coverage. All tests have been successfully executed, confirming the platform meets PSA specifications.