### PR TITLE
GNUARM.cmake: restore support for CROSS_COMPILE

### DIFF
--- a/api-tests/tools/cmake/compiler/GNUARM.cmake
+++ b/api-tests/tools/cmake/compiler/GNUARM.cmake
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2019-2023, 2026, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,11 @@
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR ARM)
 
-set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+if (DEFINED CROSS_COMPILE)
+	set(_C_TOOLCHAIN_NAME ${CROSS_COMPILE}-gcc)
+else()
+	set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+endif()
 
 if(WIN32)
     if (NOT DEFINED GNUARM_PATH)
@@ -40,7 +44,7 @@ find_program(
 
 if(_C_TOOLCHAIN_PATH STREQUAL "_C_TOOLCHAIN_PATH-NOTFOUND")
         message(FATAL_ERROR "[PSA] : Couldn't find ${_C_TOOLCHAIN_NAME}."
-                " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
+                " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH or CROSS_COMPILE properly.")
 endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)

--- a/secure-debug/tools/cmake/compiler/GNUARM.cmake
+++ b/secure-debug/tools/cmake/compiler/GNUARM.cmake
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2021-2023, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2021-2023, 2026, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,11 @@
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMKE_SYSTEM_PROCESSOR ARM)
 
-set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+if (DEFINED CROSS_COMPILE)
+	set(_C_TOOLCHAIN_NAME ${CROSS_COMPILE}-gcc)
+else()
+	set(_C_TOOLCHAIN_NAME arm-none-eabi-gcc)
+endif()
 
 if(WIN32)
     if (NOT DEFINED GNUARM_PATH)
@@ -40,7 +44,7 @@ find_program(
 
 if(_C_TOOLCHAIN_PATH STREQUAL "_C_TOOLCHAIN_PATH-NOTFOUND")
         message(FATAL_ERROR "[PSA] : Couldn't find ${_C_TOOLCHAIN_NAME}."
-                " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH set properly.")
+                " Either put ${_C_TOOLCHAIN_NAME} on the PATH or set GNUARM_PATH or CROSS_COMPILE properly.")
 endif()
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)


### PR DESCRIPTION
bf532fd06749e9dbc23c10506a3ee26df81bae6b inadvertently reverted the changes made by c50804edc29a74c9cb52744b2ffda27835dc2882 to `api-tests/tools/cmake/compiler/GNUARM.cmake`.

Restore the reverted changes and in addition also add them to `secure-debug/tools/cmake/compiler/GNUARM.cmake`.