### PR TITLE
ARMCLANG.cmake: Add option NO_FSHORT_FLAGS

### DIFF
--- a/api-tests/ff/README.md
+++ b/api-tests/ff/README.md
@@ -98,6 +98,7 @@ To build the test suite for your target platform, perform the following steps.
 ```
     -DPSA_INCLUDE_PATHS=`readlink -f <relative_include_path>`
 ```
+-   -DNO_FSHORT_FLAGS=<0|1> : This option is applicable only for ARMCLANG toolchain. 0 means compile with `-fshort-enums` and `-fshort-wchar`, while 1 means compile without those flags. Default is 0.
 
 For using FF-1.1 do the following manifests changes in api-tests/platform/manifests files.
 	Change "psa_framework_version" attribute from 1.0 to 1.1 in all manifests files.
@@ -163,4 +164,4 @@ Arm PSA test suite is distributed under Apache v2.0 License.
 
 --------------
 
-*Copyright (c) 2018-2025, Arm Limited and Contributors. All rights reserved.*
+*Copyright (c) 2018-2026, Arm Limited and Contributors. All rights reserved.*

--- a/api-tests/tools/cmake/compiler/ARMCLANG.cmake
+++ b/api-tests/tools/cmake/compiler/ARMCLANG.cmake
@@ -1,5 +1,5 @@
 #/** @file
-# * Copyright (c) 2019-2023, Arm Limited or its affiliates. All rights reserved.
+# * Copyright (c) 2019-2023, 2026, Arm Limited or its affiliates. All rights reserved.
 # * SPDX-License-Identifier : Apache-2.0
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,6 +64,14 @@ elseif(${CPU_ARCH} STREQUAL armv8a)
     set(TARGET_SWITCH "-march=armv8-a")
 endif()
 
-set(CMAKE_C_FLAGS              "--target=arm-arm-none-eabi ${TARGET_SWITCH} -g -Wall -Werror -Wextra -fshort-enums -fshort-wchar -funsigned-char -fdata-sections -ffunction-sections -mno-unaligned-access -mfpu=none")
+if (NO_FSHORT_FLAGS)
+    set(FSHORT_C_FLAGS "")
+    message(STATUS "[PSA] : Disable -fshort-enums and -fshort-wchar flags")
+else()
+    set(FSHORT_C_FLAGS "-fshort-enums -fshort-wchar")
+    message(STATUS "[PSA] : Enable -fshort-enums and -fshort-wchar flags")
+endif()
+
+set(CMAKE_C_FLAGS              "--target=arm-arm-none-eabi ${TARGET_SWITCH} -g -Wall -Werror -Wextra ${FSHORT_C_FLAGS} -funsigned-char -fdata-sections -ffunction-sections -mno-unaligned-access -mfpu=none")
 set(CMAKE_ASM_FLAGS            "${TARGET_SWITCH} -mthumb")
 set(CMAKE_EXE_LINKER_FLAGS     "--strict --map --symbols --xref  --info=summarysizes,sizes,totals,unused,veneers --diag_warning=L6204")


### PR DESCRIPTION
The default build flag set for ARMCLANG contains both -fshort-enums -fshort-wchar which can cause linking errors if the secure side is built without them.

Add a build option NO_FSHORT_FLAGS so that users can adapt the psa tests with their secure side build options.